### PR TITLE
Add ProxyClaw to Tools — residential proxy skill for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Utilities and helpers for working with OpenClaw.
 | [agents.json](agents.json) | Machine-readable index of all 100 agent templates |
 | agent-validator | Validate SOUL.md syntax |
 | mcp-tester | Test MCP server connections |
+| [ProxyClaw](https://github.com/Iploop/proxyclaw) | Residential proxy skill — 2M+ IPs, 195+ countries, anti-bot bypass. `clawhub install proxyclaw` |
 
 ---
 


### PR DESCRIPTION
Adding [ProxyClaw](https://github.com/Iploop/proxyclaw) to the Tools section.

**What:** Residential proxy skill that gives any OpenClaw agent access to 2M+ IPs across 195+ countries.
**Install:** `clawhub install proxyclaw`
**Also on:** [PyPI](https://pypi.org/project/iploop-sdk/) • [npm](https://npmjs.com/package/iploop) • [ClawHub](https://clawhub.ai/skills/proxyclaw)