### PR TITLE
Add KeyID MCP server — free agent email, SMS, OTP/TOTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Model Context Protocol servers to extend agent capabilities.
 
 | Server | Description |
 |--------|-------------|
+| [@keyid/agent-kit](https://github.com/KeyID-AI/KeyID) | Agent email, SMS, OTP/TOTP, signup sessions. Free for first 1,000 accounts (vs paid alternatives like AgentMail). `npx -y @keyid/agent-kit` or remote at `https://keyid.ai/mcp` |
 | mcp-notion | Notion integration |
 | mcp-google-calendar | Google Calendar access |
 | mcp-github | GitHub operations |


### PR DESCRIPTION
## What

Adds [KeyID](https://keyid.ai) to the Community MCP Servers section.

## Why KeyID for OpenClaw agents

KeyID gives AI agents their own email addresses, phone numbers, and verification infrastructure — zero human in the loop. **Free for the first 1,000 accounts** (unlike paid alternatives like AgentMail).

OpenClaw agents that need to:
- Register for services autonomously
- Verify email or SMS codes
- Handle TOTP/authenticator flows
- Manage credentials securely

...can use KeyID out of the box.

## Details

- **npm**: `@keyid/agent-kit` (47 tools, 8 prompts)
- **Remote MCP**: `https://keyid.ai/mcp` (no install needed)
- **Install**: `npx -y @keyid/agent-kit`
- **Free tier**: 1,000 agent accounts at no cost
- **License**: MIT