### PR TITLE
Add Claude Code Starter Kit to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Utilities and helpers for working with OpenClaw.
 |------|-------------|
 | [openclaw CLI](https://crewclaw.com/blog/openclaw-cli-commands-reference) | Official CLI - complete command reference |
 | [agents.json](agents.json) | Machine-readable index of all 187 agent templates |
+| [Claude Code Starter Kit](https://github.com/rmbell09-lang/claude-code-starter-kit) | Production-ready workspace kit: SOUL.md, AGENTS.md, MEMORY.md templates + skills for persistent OpenClaw agents |
 | agent-validator | Validate SOUL.md syntax |
 | mcp-tester | Test MCP server connections |
 


### PR DESCRIPTION
## Summary

Adding [Claude Code Starter Kit](https://github.com/rmbell09-lang/claude-code-starter-kit) to the Tools section.

**What it is:** A production-ready workspace kit for OpenClaw agents. Provides copy-paste templates for SOUL.md, AGENTS.md, USER.md, IDENTITY.md, MEMORY.md, plus 5 battle-tested skills (coding-agent, model-router, collaborative-research, market-research, healthcheck).

**Why it belongs here:** It's specifically designed to set up persistent, self-improving OpenClaw agents. Used in production to run autonomous agents with memory, personality, and purpose from day one — no blank-page config required.

**Repo:** https://github.com/rmbell09-lang/claude-code-starter-kit
