### PR TITLE
Add XVARY Stock Research (Claude Code skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,11 @@ Want to request an agent instead? Use the [Agent Request](https://github.com/mer
 
 ---
 
+## XVARY Stock Research
+
+- [XVARY Stock Research](https://github.com/xvary-research/claude-code-stock-analysis-skill) — Claude Code skill for public SEC EDGAR + market data: `/analyze`, `/score`, `/compare`. MIT.
+
+
 ## License
 
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
Adds [xvary-research/claude-code-stock-analysis-skill](https://github.com/xvary-research/claude-code-stock-analysis-skill) — MIT, public SEC EDGAR + market data workflow (`/analyze`, `/score`, `/compare`) for Claude Code / compatible agents.

Inserted as a short README section before Contributing/License where possible.