### PR TITLE
Add SkillFlow - AI Skills Marketplace & MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ Connect your agents to external services.
 
 ## Tools
 
+- [SkillFlow](https://github.com/rafsilva85/skillflow-mcp-server) - Open marketplace for AI agent skills and MCP servers. Browse, discover, and install 500+ skills.
 Utilities and helpers for working with OpenClaw.
 
 | Tool | Description |


### PR DESCRIPTION
## SkillFlow

**[SkillFlow](https://skillflow.builders)** is an open marketplace for AI agent skills and MCP servers.

- **npm**: `skillflow-mcp-server`
- **Official MCP Registry**: `io.github.rafsilva85/skillflow`
- **GitHub**: https://github.com/rafsilva85/skillflow-mcp-server

SkillFlow helps teams discover, share, and install AI capabilities. Currently featuring 500+ skills across multiple categories.