### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ Skills for Gemma 4 running on iPhone / Android via [Google AI Edge Gallery](http
 ### [Claude](./skills/claude/) — Claude Code
 Skills for [Claude Code](https://claude.com/claude-code), invoked via slash commands or automatic triggers.
 
+- **[mmx-cli](https://github.com/MiniMax-AI/cli)** — Generate text, images, video, speech, and music via MiniMax AI
+
 **[Browse all skills →](./skills/)**
 
 ---

--- a/skills/claude/README.md
+++ b/skills/claude/README.md
@@ -27,6 +27,10 @@ description: When to trigger this skill
 What the skill should do...
 ```
 
-## Skills coming soon
+## Skills
 
-This folder is a placeholder for Claude Code skills. Add yours via PR.
+| Skill | Description | Source |
+|-------|-------------|--------|
+| [mmx-cli](https://github.com/MiniMax-AI/cli) | Generate text, images, video, speech, and music via MiniMax AI | MiniMax-AI/cli |
+
+Add yours via PR.


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to the Claude Code skills section in `skills/claude/README.md` so the mmx-cli skill is discoverable out of the box
- Also listed under `## Skills > ### Claude` in the main `README.md`
- Users can install via `cp -r mmx-cli ~/.claude/skills/` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**2 files changed, 8 insertions, 2 deletions.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- `skills/claude/README.md` lists the mmx-cli skill with a link to `MiniMax-AI/cli`
- Browsing `./skills/` shows mmx-cli under Claude Code skills
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal