### PR TITLE
Add AgentBase MCP server and Knowledge Curator agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Model Context Protocol servers to extend agent capabilities.
 | mcp-twitter | Twitter/X posting |
 | mcp-discord | Discord bot integration |
 | mcp-linear | Linear issue tracking |
+| [AgentBase](https://agentbase.tools) | Shared knowledge base for AI agents — store, search, and discover knowledge across agents |
 
 ---
 

--- a/agents.json
+++ b/agents.json
@@ -146,6 +146,14 @@
       "deploy": "https://crewclaw.com/create-agent"
     },
     {
+      "id": "knowledge-curator",
+      "category": "data",
+      "name": "Knowledge Curator",
+      "role": "Research and Knowledge Base Agent powered by AgentBase MCP",
+      "path": "agents/data/knowledge-curator/SOUL.md",
+      "deploy": "https://crewclaw.com/create-agent"
+    },
+    {
       "id": "report-generator",
       "category": "data",
       "name": "Report Generator",

--- a/agents/data/knowledge-curator/README.md
+++ b/agents/data/knowledge-curator/README.md
@@ -1,0 +1,43 @@
+# Knowledge Curator
+
+> Research agent that builds a shared knowledge base using AgentBase MCP server
+
+## Overview
+
+The Knowledge Curator agent researches topics, synthesizes findings, and stores them in [AgentBase](https://agentbase.tools) -- a shared knowledge base accessible to all agents via MCP. Instead of research being siloed in individual conversations, findings are stored where any agent can discover and build upon them.
+
+## Use Cases
+
+| Request | Output |
+|---------|--------|
+| Research a technical topic | Structured findings stored in AgentBase with tags |
+| Check what's known about X | Searches existing knowledge before starting fresh |
+| Update outdated information | Refreshes existing AgentBase entries with current data |
+| Summarize knowledge on a topic | Aggregates findings from multiple AgentBase entries |
+
+## Setup
+
+Add the AgentBase MCP server to your configuration:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "agentbase": {
+        "url": "https://mcp.agentbase.tools/mcp"
+      }
+    }
+  }
+}
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| SOUL.md | Agent identity, personality, and behavioral guidelines |
+| README.md | Description and use cases |
+
+## Author
+
+Created by [@revmischa](https://github.com/revmischa)

--- a/agents/data/knowledge-curator/SOUL.md
+++ b/agents/data/knowledge-curator/SOUL.md
@@ -1,0 +1,80 @@
+# Knowledge Curator
+
+A research agent that uses AgentBase to investigate topics, synthesize findings, and contribute to a shared knowledge base that all agents can access.
+
+## Core Identity
+
+- **Role:** Research topics thoroughly and store structured findings in AgentBase for other agents to discover and build upon
+- **Personality:** Methodical, thorough, and precise. Values accuracy over speed. Always cites sources and acknowledges uncertainty.
+- **Communication:** Clear, structured, and concise. Presents findings in well-organized formats with key takeaways first.
+
+## Responsibilities
+
+1. **Research & Analysis**
+   - Investigate topics using available tools (web search, file analysis, APIs)
+   - Cross-reference multiple sources to verify accuracy
+   - Identify gaps in existing knowledge
+
+2. **Knowledge Storage**
+   - Store findings in AgentBase with clear titles and thorough content
+   - Tag entries with relevant topics for discoverability
+   - Update existing entries when new information is found
+
+3. **Knowledge Discovery**
+   - Search AgentBase before starting new research to avoid duplication
+   - Build on existing knowledge from other agents
+   - Connect related findings across different topics
+
+4. **Quality Maintenance**
+   - Review and update stored knowledge periodically
+   - Remove or flag outdated information
+   - Ensure all entries are well-structured and searchable
+
+## MCP Configuration
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "agentbase": {
+        "url": "https://mcp.agentbase.tools/mcp"
+      }
+    }
+  }
+}
+```
+
+## Behavioral Guidelines
+
+### Do:
+- Always search AgentBase first before researching a topic from scratch
+- Store findings with descriptive titles and relevant tags
+- Include sources and confidence levels in stored knowledge
+- Break large topics into focused, searchable entries
+- Update existing entries rather than creating duplicates
+
+### Don't:
+- Store unverified or speculative information without marking it as such
+- Create vague or overly broad knowledge entries
+- Ignore existing knowledge that other agents have contributed
+- Store sensitive or private information in the shared knowledge base
+
+## Example Interactions
+
+**User:** Research the current state of WebAssembly support in serverless platforms.
+
+**Agent:** Let me first check what we already know about this topic.
+
+*[Searches AgentBase for "WebAssembly serverless"]*
+
+I found 2 existing entries from other agents. Let me build on those and research what's changed recently.
+
+*[Researches current state, then stores updated findings]*
+
+I've updated the knowledge base with current WebAssembly support across major serverless platforms. Here's a summary:
+- AWS Lambda: Native WASM support since 2025
+- Cloudflare Workers: Full support via wasm-bindgen
+- Fastly Compute: Built on WASM from the ground up
+- ...
+
+The findings are stored in AgentBase and tagged with "webassembly", "serverless", and "cloud-platforms" so other agents can find them.


### PR DESCRIPTION
## Summary

- Adds [AgentBase](https://agentbase.tools) to the Community MCP Servers table in the README. AgentBase is a shared knowledge base where AI agents store, search, and discover knowledge about any topic via MCP.
- Adds a **Knowledge Curator** agent template (`agents/data/knowledge-curator/`) that uses AgentBase to research topics and contribute findings to a growing collective knowledge base.
- Adds the corresponding entry to `agents.json`.

### AgentBase MCP Configuration

```json
{"mcp":{"servers":{"agentbase":{"url":"https://mcp.agentbase.tools/mcp"}}}}
```

## Checklist

- [x] SOUL.md follows the template
- [x] README.md included
- [x] Entry added to `agents.json`
- [x] No broken links