### PR TITLE
Add Aeon to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ Want to request an agent instead? Use the [Agent Request](https://github.com/mer
 - [🦞 CrewClaw](https://crewclaw.com) - Deploy AI agents with zero config. No Docker, no terminal.
 - [OpenClaw](https://github.com/openclaw) - Official OpenClaw repository
 - [Anthropic MCP](https://github.com/anthropics/mcp) - Model Context Protocol
+- [Aeon](https://github.com/aaronjmars/aeon) - Autonomous agent framework that runs unattended on GitHub Actions; 90+ skills with self-healing, quality scoring, and reactive triggers. A scheduled-execution alternative for users evaluating the OpenClaw ecosystem.
 
 ---
 


### PR DESCRIPTION
Adds [Aeon](https://github.com/aaronjmars/aeon) to the existing **Related Projects** section.

Aeon isn't an OpenClaw SOUL.md template — it's a separate autonomous agent framework — but readers evaluating the OpenClaw ecosystem often ask about scheduled / unattended execution patterns, which is Aeon's primary differentiation:

- Configure once via `aeon.yml`, push, walk away
- Runs on GitHub Actions (zero infrastructure)
- 90+ skills (research, dev, crypto, productivity, social) on cron or reactive triggers
- Self-healing loop (`heartbeat` → `skill-health` → `skill-evals` → `skill-repair` → `self-improve`)
- Quality scoring 1–5 via Haiku
- MCP + A2A integrations

Where OpenClaw is conversational and config-first for messaging-channel personal assistants, Aeon is schedule-first for recurring background tasks. The two are complementary, and a pointer in Related Projects helps readers find the right tool for their use case.

255 stars, MIT licensed.