### PR TITLE
Add Lumin — local-first observability integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Connect your agents to external services.
 
 ### Observability
 
-- **[Synaptic](https://github.com/amitbidlan/zistica-synaptic)** - Local-first AI observability. Records every LLM call, tool call, and decision; runs in one Docker container; no account, no cloud. Plug into OpenClaw's OTel pipeline via [`@synaptic/openclaw`](https://github.com/amitbidlan/zistica-synaptic/tree/main/packages/integrations/openclaw); browse traces at `localhost:3000`.
+- **[Synaptic](https://github.com/amitbidlan/zistica-synaptic)** - Local-first AI observability. Records every LLM call, tool call, and decision; runs in one Docker container; no account, no cloud. Plug into OpenClaw's OTel pipeline via [`@zistica-synaptic/openclaw`](https://github.com/amitbidlan/zistica-synaptic/tree/main/packages/integrations/openclaw); browse traces at `localhost:3000`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Connect your agents to external services.
 
 ### Observability
 
-- **[Synaptic](https://github.com/amitbidlan/zistica-synaptic)** - Local-first AI observability. Records every LLM call, tool call, and decision; runs in one Docker container; no account, no cloud. Plug into OpenClaw's OTel pipeline via [`@zistica-synaptic/openclaw`](https://github.com/amitbidlan/zistica-synaptic/tree/main/packages/integrations/openclaw); browse traces at `localhost:3000`.
+- **[Lumin](https://github.com/amitbidlan/zistica-lumin)** - Local-first AI observability. Records every LLM call, tool call, and decision; runs in one Docker container; no account, no cloud. Plug into OpenClaw's OTel pipeline via [`@lumin-io/openclaw`](https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw); browse traces at `localhost:3000`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -634,6 +634,10 @@ Connect your agents to external services.
 - **GitHub Actions** - CI/CD integration
 - **Cron / pm2 / systemd** - Always-on agent scheduling
 
+### Observability
+
+- **[Synaptic](https://github.com/amitbidlan/zistica-synaptic)** - Local-first AI observability. Records every LLM call, tool call, and decision; runs in one Docker container; no account, no cloud. Plug into OpenClaw's OTel pipeline via [`@synaptic/openclaw`](https://github.com/amitbidlan/zistica-synaptic/tree/main/packages/integrations/openclaw); browse traces at `localhost:3000`.
+
 ---
 
 ## Tools


### PR DESCRIPTION
Adds [Lumin](https://github.com/amitbidlan/zistica-lumin) under **Infrastructure → Observability**.

## What it is

Lumin is a local-first observability platform for AI agents. It records every LLM call, tool call, and decision, runs in a single Docker container, and exposes a dashboard at `localhost:3000`. No account, no cloud, Apache-2.0 licensed.

## Why it fits OpenClaw's ecosystem

OpenClaw already emits OpenTelemetry through `@openclaw/diagnostics-otel`. Lumin ships a companion package — [`@lumin-io/openclaw`](https://github.com/amitbidlan/zistica-lumin/tree/main/packages/integrations/openclaw) — that's an OTel `SpanExporter` mapping OpenClaw's spans to Lumin's wire format. Same "your data, your machine" philosophy as OpenClaw itself.

## Install

```bash
docker run -p 3000:3000 -p 8000:8000 zistica/lumin
npm install @lumin-io/openclaw
```

```ts
import { luminProcessor } from '@lumin-io/openclaw';

const tracerProvider = new NodeTracerProvider({
  resource,
  spanProcessors: [luminProcessor()],
});
```

Channel sessions (WhatsApp / Telegram / Discord / Slack / iMessage) are grouped via the dashboard's `/sessions` view; Claude extended-thinking blocks render as first-class child spans with separate cost rows.

## Checklist

- [x] One entry, alphabetical within the section
- [x] Bold name with link, em dash, one-line description
- [x] No commercial pitch — Apache-2.0, free, local
- [x] Working repo + working install command