### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Utilities and helpers for working with OpenClaw.
 | [agents.json](agents.json) | Machine-readable index of all 187 agent templates |
 | agent-validator | Validate SOUL.md syntax |
 | mcp-tester | Test MCP server connections |
+| [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) | Pre-action authorization and blocked-pattern checks for OpenClaw agent tool calls |
 
 ---
 


### PR DESCRIPTION
Adds APort Agent Guardrails to the OpenClaw tools list.

APort is a close fit because its documented before_tool_call hook provides pre-action authorization and blocked-pattern checks for OpenClaw agent tool execution.

Submitted for aporthq/aport-integrations#19.