### PR TITLE
feat: add TWZRD Agent Intel - Solana x402 MCP agent trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ Model Context Protocol servers to extend agent capabilities.
 | mcp-twitter | Twitter/X posting |
 | mcp-discord | Discord bot integration |
 | mcp-linear | Linear issue tracking |
+| [twzrd-agent-intel](https://intel.twzrd.xyz) | Solana on-chain agent trust scoring via x402 micropayments — 4 free preflight tools + 4 paid signed V5 trust receipts. MCP at `https://intel.twzrd.xyz/mcp` |
 
 ---
 


### PR DESCRIPTION
## What

Adds TWZRD Agent Intel to the MCP Servers → Community table.

## Entry

| [twzrd-agent-intel](https://intel.twzrd.xyz) | Solana on-chain agent trust scoring via x402 micropayments — 4 free preflight tools + 4 paid signed V5 trust receipts. MCP at `https://intel.twzrd.xyz/mcp` |

## Why

TWZRD Agent Intel is a hosted, streamable-http MCP server that gives OpenClaw/Claude agents the ability to:
1. Score any Solana wallet for trustworthiness before interacting
2. Get signed `twzrd.receipt.v5` trust tokens for autonomous agent transactions (x402 HTTP 402 + USDC on Solana)

It extends agent capabilities in the payments/trust space — directly useful for autonomous agent-to-agent commerce on Solana.
