### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Pick a template, see what it does, get a Dockerfile + docker-compose + bot + REA
 - [Security](#security)
 - [Tutorials & Guides](#tutorials--guides)
 - [Cost Optimization & Multi-Provider](#-cost-optimization--multi-provider)
-- [Model Configs](#model-configs) `NEW` — drop-in GLM-5.1, Minimax M2.7, GPT-5.4, advisor hybrid
+- [Model Configs](#model-configs) `NEW` — drop-in GLM-5.1, Minimax M3, GPT-5.4, advisor hybrid
 - [Memory Wiki](#memory-wiki) `NEW` — Karpathy-style pre-compiled agent memory
 - [Troubleshooting](TROUBLESHOOTING.md) `NEW` — known issues, regressions, recovery
 - [Submit Your Agent](#submit-your-agent)
@@ -472,7 +472,7 @@ Skills for [Claude Code](https://claude.com/claude-code), invoked via slash comm
 
 - **[git-commit-writer](./skills/claude/git-commit-writer/)** — Draft opinionated commit messages from staged changes, matching repo conventions
 - **[openclaw-debugger](./skills/claude/openclaw-debugger/)** — 6-step diagnosis checklist when an OpenClaw agent is dead or misbehaving
-- **[model-cost-compare](./skills/claude/model-cost-compare/)** — Estimate token cost across Opus, Sonnet, GLM-5.1, Minimax M2.7, local Gemma for a task
+- **[model-cost-compare](./skills/claude/model-cost-compare/)** — Estimate token cost across Opus, Sonnet, GLM-5.1, Minimax M3, local Gemma for a task
 - **[excalidraw-architecture](./skills/claude/excalidraw-architecture/)** — Generate/update an Excalidraw architecture diagram from the current codebase
 - **[cost-optimizer](./skills/claude/cost-optimizer/)** — Audit a project's Claude Code usage for cost wins (bloated memory, cache misses, over-pinned Opus)
 
@@ -780,7 +780,7 @@ Drop-in OpenClaw configs for migrating off Claude. Each bundle contains a `READM
 | Bundle | When to use | Notes |
 |--------|-------------|-------|
 | [configs/glm-5.1](configs/glm-5.1/) | Community-reported closest Opus 4.6 alternative | Strong tool-calling, stricter JSON mode |
-| [configs/minimax-m2.7](configs/minimax-m2.7/) | Agentic SWE workloads | 229B params · SWE-Pro 56.22% · check license |
+| [configs/minimax-m2.7](configs/minimax-m2.7/) | Agentic SWE workloads | MiniMax M3 default · M2.7 (229B, SWE-Pro 56.22%) supported · check license |
 | [configs/gpt-5.4](configs/gpt-5.4/) | Already on ChatGPT/OpenAI billing | Use `thinking=high + fastmode=true` |
 | [configs/advisor-hybrid](configs/advisor-hybrid/) | High-complexity + cost-sensitive | Opus 4.6 advises, cheap model executes |
 | [configs/ollama](configs/ollama/) | Fully local, zero API cost | Gemma 4 / Qwen 3 / DeepSeek |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ Start here. Match the symptom, confirm the cause in the linked section, then app
 | `openclaw agent --status` returns `UNKNOWN` | Sessions file corruption | Delete `~/.openclaw/agents/<name>/sessions/sessions.json` | [Bot is dead](#bot-is-dead--unresponsive) |
 | Claude API key banned despite pay-as-you-go | Burst rate-limit tripped abuse detection | Contact Anthropic support, throttle retries | [Claude Opus/Sonnet](#claude-opussonnet) |
 | GPT 5.4 "feels lobotomized" in OpenClaw | Config issue, not the model | Set `thinking=high` + `fastmode=true` | [GPT 5.4](#gpt-54) |
-| Minimax M2.7 agent refuses commercial tasks | Commercial license caveat | Switch provider or obtain license | [Minimax M2.7](#minimax-m27) |
+| Minimax agent refuses commercial tasks | Self-hosted M2.7 commercial license caveat | Switch to hosted M3 or obtain license | [Minimax](#minimax) |
 | Memory files grow unbounded, latency creeps up | Context bloat | Compile memory, prune unused entries | [Context bloat](#context-bloat-from-memory-files) |
 | Opus token count climbs with no new tasks | Advisor executor runaway loop | Kill executor, check `last-plan.json` | [Advisor loop runaway](#advisor-loop-runaway) |
 | Bot process alive but all agents report `stale` | Gateway heartbeat thread died | Restart gateway (`openclaw gateway restart`) | [Heartbeat](#heartbeat-failure-modes) |
@@ -269,11 +269,13 @@ Three live issues to know about:
 
 Generally stable. Known constraint: the OpenClaw provider adapter does not support tool streaming on GLM-5.1 yet, so tool-heavy agents will feel laggy. If your agent uses tools, prefer Claude or GPT.
 
-### Minimax M2.7
+### Minimax
 
-**Commercial license caveat:** the M2.7 checkpoint most people pull from the model hub is non-commercial only. If you use it in a product, you need a commercial license from Minimax. This is not an OpenClaw bug — but agents using M2.7 will sometimes refuse to complete commercial-looking prompts due to the system-level license notice baked into the weights.
+The bundle defaults to **MiniMax M3** on the hosted API (512K context, up to 128K output, image input), with M2.7 still supported for users who self-host the open weights.
 
-Fix: either obtain the commercial license, or swap to a different model for commercial deployments.
+**Commercial license caveat (self-hosted M2.7 only):** the M2.7 checkpoint most people pull from the model hub is non-commercial only. If you use it in a product, you need a commercial license from Minimax. This is not an OpenClaw bug — but agents using self-hosted M2.7 will sometimes refuse to complete commercial-looking prompts due to the system-level license notice baked into the weights.
+
+Fix: either obtain the commercial license, or use the hosted M3 / M2.7 API (whose TOS supersedes the weights license) for commercial deployments.
 
 ---
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -8,13 +8,13 @@ Drop-in agent configs for different model providers. Each folder is a self-conta
 |--------|----------|----------|--------|
 | [ollama](./ollama) | Local Ollama | Private, offline, no API cost | Stable |
 | [glm-5.1](./glm-5.1) | Zhipu GLM-5.1 | Opus 4.6 alternative, long-horizon coding | New |
-| [minimax-m2.7](./minimax-m2.7) | MiniMax M2.7 (229B) | Agentic SWE tasks, terminal workflows | New |
+| [minimax-m2.7](./minimax-m2.7) | MiniMax M3 (default) / M2.7 (229B) | Agentic SWE tasks, terminal workflows | New |
 | [gpt-5.4](./gpt-5.4) | OpenAI GPT-5.4 | Reasoning-heavy tasks, Codex workflows | New |
 
 ## Which one should I pick?
 
 - **You can't get on Claude right now** (Anthropic ban, quota exhausted, Alibaba resellers sold out) → start with **glm-5.1**. It's the closest drop-in for Opus 4.6 prompts and most community threads on r/openclaw rank it first.
-- **You want open weights + the best agentic scores** → **minimax-m2.7**. Heavier to self-host, but SWE-Pro 56.22% is the highest open-weight number as of April 2026.
+- **You want open weights + the best agentic scores** → **minimax-m2.7** (the bundle now defaults to **MiniMax M3** on hosted API, with M2.7 still supported for self-hosters). Heavier to self-host, but SWE-Pro 56.22% is the highest open-weight number as of April 2026.
 - **You already have an OpenAI key and want official support** → **gpt-5.4**. It needs prompt surgery coming from Claude, but the `thinking=high + fastmode=true` combo is solid once configured.
 - **You want zero vendor lock-in, private data, no network** → **ollama**.
 

--- a/configs/minimax-m2.7/.env.example
+++ b/configs/minimax-m2.7/.env.example
@@ -1,11 +1,11 @@
 # MiniMax hosted API key
-# Get one from https://platform.minimax.chat/ (verify current URL in official docs)
+# Get one from https://platform.minimax.io/ (verify current URL in official docs)
 MINIMAX_API_KEY=your-minimax-api-key-here
 
 # Optional: override base URL.
-# Default hosted: https://api.minimax.chat/v1
-# MINIMAX_BASE_URL=https://api.minimax.chat/v1
+# Default hosted: https://api.minimax.io/v1
+# MINIMAX_BASE_URL=https://api.minimax.io/v1
 
-# Optional: if you are self-hosting the 229B weights behind vLLM / SGLang,
-# point OpenClaw at your local endpoint instead.
+# Optional: if you are self-hosting the 229B M2.7 weights behind vLLM / SGLang,
+# point OpenClaw at your local endpoint instead. (M3 is hosted-only today.)
 # MINIMAX_BASE_URL=http://localhost:8000/v1

--- a/configs/minimax-m2.7/README.md
+++ b/configs/minimax-m2.7/README.md
@@ -1,31 +1,37 @@
-# MiniMax M2.7 Agent Configs
+# MiniMax Agent Configs (M3 default)
 
-Drop-in OpenClaw configs for **MiniMax M2.7** — a 229B-parameter open-weight model that currently posts the highest agentic coding scores of any non-Anthropic model.
+Drop-in OpenClaw configs for **MiniMax M3** — the latest MiniMax model, with a 512K context window, up to 128K output, and image input. M2.7 is still supported as an alternative for users with existing self-hosted weights.
 
-## Why MiniMax M2.7
+## Why MiniMax M3
 
-The short version: if you care about raw SWE-bench-style agentic performance and you are okay either paying MiniMax's hosted API or running 229B weights yourself, this is the strongest option on the board right now.
+The short version: if you care about raw SWE-bench-style agentic performance and you are okay paying MiniMax's hosted API (or holding onto the 229B M2.7 weights), this is the strongest option on the board right now.
 
-Reported numbers (from MiniMax's own release page — treat as vendor-reported until independently verified):
+M3 highlights (hosted API):
+
+- **512K context window**, up to **128K output**
+- **Image input** supported (OpenAI- and Anthropic-compatible endpoints)
+- Drop-in replacement for M2.7 prompts — no SOUL.md rewrite required
+
+M2.7 reported numbers (from MiniMax's own release page — treat as vendor-reported until independently verified):
 
 - **229B parameters** (MoE, open weights)
 - **SWE-Pro: 56.22%**
 - **Terminal Bench 2: 57%**
 
-Those are the two benchmarks r/openclaw users keep citing in the migration megathread. Real-world reports from users who actually switched describe it as "almost Opus-level on long tool chains, slightly worse on one-shot snippets."
+Those are the benchmarks r/openclaw users keep citing in the migration megathread. Real-world reports from users who switched describe M2.7 as "almost Opus-level on long tool chains, slightly worse on one-shot snippets." M3 builds on the same agentic training recipe.
 
 ## Quick Start
 
 1. Either:
-   - Get an API key from the MiniMax platform, OR
-   - Self-host the weights (you'll need ~4x H100 for full precision; see the MiniMax HuggingFace model card for quantized variants)
+   - Get an API key from the MiniMax platform (recommended — M3 is hosted-only for now), OR
+   - Self-host the M2.7 weights (you'll need ~4x H100 for full precision; see the MiniMax HuggingFace model card for quantized variants)
 
 2. Register the provider with OpenClaw:
 
 ```bash
 openclaw provider add minimax \
   --api-key $MINIMAX_API_KEY \
-  --base-url https://api.minimax.chat/v1
+  --base-url https://api.minimax.io/v1
 ```
 
 3. Copy the agent bundle:
@@ -44,9 +50,9 @@ openclaw agent --agent swe-agent --message "Find and fix the failing tests in th
 
 | Model ID | Context | Good For |
 |----------|---------|----------|
-| `minimax-m2.7` | 256K | Default. Full weights. |
-| `minimax-m2.7-turbo` | 128K | Same weights, lower latency, slightly higher price. |
-| `minimax-m2.7-mini` | 128K | A distilled 34B version. Use for cheap routing. |
+| `minimax-m3` | 512K | **Default.** Latest hosted model. 128K max output, image input. |
+| `minimax-m2.7` | 256K | Previous gen. Full open weights available for self-hosting. |
+| `minimax-m2.7-highspeed` | 256K | Previous gen, low-latency hosted variant. |
 
 ## About `mmx-cli`
 
@@ -54,31 +60,32 @@ MiniMax also ships their own CLI called `mmx-cli` that wraps the same API with a
 
 ## Commercial License Caveat
 
-**Read the license before you ship.** MiniMax M2.7's open weights are released under a source-available license that restricts certain commercial uses — specifically, companies above a revenue threshold need a separate commercial agreement. If you are:
+**Read the license before you self-host.** MiniMax M2.7's open weights are released under a source-available license that restricts certain commercial uses — specifically, companies above a revenue threshold need a separate commercial agreement. If you are:
 
 - Solo / hobby / research → you're fine under the default terms
-- Using MiniMax's **hosted API** → you're fine (the API TOS supersedes the weights license)
-- A commercial product self-hosting the weights → talk to a lawyer before you deploy
+- Using MiniMax's **hosted API** (M3 or M2.7) → you're fine (the API TOS supersedes the weights license)
+- A commercial product self-hosting the M2.7 weights → talk to a lawyer before you deploy
 
-This is not legal advice. This is "don't get surprised by a cease-and-desist." See the HuggingFace model card for the current license text.
+This is not legal advice. This is "don't get surprised by a cease-and-desist." See the HuggingFace model card for the current license text. M3 is hosted-only, so the weights license does not apply to it.
 
-## Cost Comparison (April 2026)
+## Cost Comparison (June 2026)
 
-| Model | Input | Output | Notes |
-|-------|-------|--------|-------|
-| Claude Opus 4.6 | $15 | $75 | |
-| **MiniMax M2.7 (hosted)** | **$1.20** | **$4.80** | |
-| MiniMax M2.7 (self-hosted) | — | — | Your GPU bill. Break-even around 4-5M output tokens/day. |
+| Model | Input ($/M) | Output ($/M) | Cache read ($/M) | Notes |
+|-------|------------:|-------------:|-----------------:|-------|
+| Claude Opus 4.6 | $15 | $75 | — | |
+| **MiniMax M3 (hosted)** | **$0.60** | **$2.40** | **$0.12** | Default. 512K context. |
+| MiniMax M2.7 (hosted) | $1.20 | $4.80 | — | Previous gen. |
+| MiniMax M2.7 (self-hosted) | — | — | — | Your GPU bill. Break-even around 4-5M output tokens/day. |
 
 ## Gotchas When Migrating From Claude
 
-1. **Aggressive tool calling.** M2.7 will call tools faster and more often than Claude. If your agent has side-effectful tools (writes files, runs shell), tighten the rules in `SOUL.md` about when it's allowed to act without confirmation. The example SOUL.md in this folder does this.
+1. **Aggressive tool calling.** MiniMax models (both M3 and M2.7) will call tools faster and more often than Claude. If your agent has side-effectful tools (writes files, runs shell), tighten the rules in `SOUL.md` about when it's allowed to act without confirmation. The example SOUL.md in this folder does this.
 
 2. **Chains get long.** Because it's trained for agentic workflows, it will happily run 40+ tool calls in a single task. Set a max-steps cap in your OpenClaw config if you care about runaway cost.
 
-3. **Worse at pure chat.** If the user asks a philosophical or open-ended question, M2.7 often responds like it's still trying to execute a task. For general-purpose chat, use a different model.
+3. **Worse at pure chat.** If the user asks a philosophical or open-ended question, the model often responds like it's still trying to execute a task. For general-purpose chat, use a different model.
 
-4. **Self-hosted: watch your KV cache.** At 256K context the KV cache will eat VRAM. Most users end up running it at 64K effective context unless they're on 8x H100.
+4. **Self-hosted M2.7: watch your KV cache.** At 256K context the KV cache will eat VRAM. Most self-hosters end up running M2.7 at 64K effective context unless they're on 8x H100. M3's 512K context is only available via the hosted API today.
 
 ## Related Threads
 

--- a/configs/minimax-m2.7/SOUL.md
+++ b/configs/minimax-m2.7/SOUL.md
@@ -1,8 +1,8 @@
-# SWE Agent (MiniMax M2.7)
+# SWE Agent (MiniMax M3)
 
 ## Identity
 - **Role:** Autonomous Software Engineering Agent
-- **Model:** minimax/minimax-m2.7
+- **Model:** minimax/minimax-m3
 - **Tone:** Action-first, terse, structured
 
 ## Personality

--- a/skills/claude/README.md
+++ b/skills/claude/README.md
@@ -10,7 +10,7 @@ Tested against Claude Code on Opus 4.6 and Sonnet 4.6 (OpenClaw 2026.4.11 ecosys
 |---|---|---|
 | [git-commit-writer](./git-commit-writer/) | Drafts an opinionated commit message from your staged diff, matching the repo's existing convention. | `cp -r skills/claude/git-commit-writer ~/.claude/skills/` |
 | [openclaw-debugger](./openclaw-debugger/) | Walks the standard OpenClaw agent diagnosis checklist (gateway, logs, heartbeat, sessions, model provider) and prints a fix. | `cp -r skills/claude/openclaw-debugger ~/.claude/skills/` |
-| [model-cost-compare](./model-cost-compare/) | Estimates token cost for a task across Opus 4.6, Sonnet 4.6, GLM-5.1, Minimax M2.7, and local Gemma 4, then recommends the cheapest capable model. | `cp -r skills/claude/model-cost-compare ~/.claude/skills/` |
+| [model-cost-compare](./model-cost-compare/) | Estimates token cost for a task across Opus 4.6, Sonnet 4.6, GLM-5.1, Minimax M3, and local Gemma 4, then recommends the cheapest capable model. | `cp -r skills/claude/model-cost-compare ~/.claude/skills/` |
 | [excalidraw-architecture](./excalidraw-architecture/) | Generates or updates `docs/architecture.excalidraw` by surveying the codebase's entry points and data stores. Inspired by @bibryam. | `cp -r skills/claude/excalidraw-architecture ~/.claude/skills/` |
 | [cost-optimizer](./cost-optimizer/) | Static audit of a project for the common Claude Code cost leaks — bloated CLAUDE.md, memory, cache-busting hooks, over-pinned Opus. | `cp -r skills/claude/cost-optimizer ~/.claude/skills/` |
 

--- a/skills/claude/model-cost-compare/SKILL.md
+++ b/skills/claude/model-cost-compare/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-cost-compare
-description: Trigger when the user asks which model to use, wants to compare model costs, says "what's cheapest for this task", "should I use Opus or Sonnet", "can a smaller model handle this", or "/model-cost-compare". Estimates token cost across Opus 4.6, Sonnet 4.6, GLM-5.1, Minimax M2.7, and local Gemma 4, then recommends the cheapest model capable of the task.
+description: Trigger when the user asks which model to use, wants to compare model costs, says "what's cheapest for this task", "should I use Opus or Sonnet", "can a smaller model handle this", or "/model-cost-compare". Estimates token cost across Opus 4.6, Sonnet 4.6, GLM-5.1, Minimax M3, and local Gemma 4, then recommends the cheapest model capable of the task.
 ---
 
 # Model Cost Compare
@@ -23,7 +23,7 @@ Use these rough figures. They are **not** exact; confirm before quoting real num
 | Opus 4.6 (1M) | Frontier | ~$15 | ~$75 | 1M | Agentic, long-context, hard reasoning |
 | Sonnet 4.6 | Mid | ~$3 | ~$15 | 400k | Everyday coding, agents, drafting |
 | GLM-5.1 | Budget hosted | ~$0.60 | ~$2.20 | 256k | Cheap bulk work, decent reasoning |
-| Minimax M2.7 | Budget hosted | ~$0.40 | ~$1.80 | 256k | Very cheap, OK for templated output |
+| Minimax M3 | Budget hosted | ~$0.60 | ~$2.40 | 512k | Agentic SWE, long-context, image input |
 | Gemma 4 (local) | On device | $0 marginal | $0 marginal | 32k | Free but slow, weak at multi-step logic |
 
 > Indicative pricing as of OpenClaw 2026.4.11. Check the provider docs before billing decisions.
@@ -59,7 +59,7 @@ Total tokens: 4M input, 200k output
 | Model       | Input cost | Output cost | Total   | Capable? |
 |-------------|-----------:|------------:|--------:|---------:|
 | **Gemma 4** |     $0.00  |      $0.00  |  $0.00  |   yes    |
-| Minimax M2.7|     $1.60  |      $0.36  |  $1.96  |   yes    |
+| Minimax M3  |     $2.40  |      $0.48  |  $2.88  |   yes    |
 | GLM-5.1     |     $2.40  |      $0.44  |  $2.84  |   yes    |
 | Sonnet 4.6  |    $12.00  |      $3.00  | $15.00  |   yes    |
 | Opus 4.6    |    $60.00  |     $15.00  | $75.00  |   overkill |

--- a/skills/claude/openclaw-debugger/SKILL.md
+++ b/skills/claude/openclaw-debugger/SKILL.md
@@ -65,7 +65,7 @@ ls -la ~/.openclaw/agents/<name>/sessions/sessions.json
 Read `~/.openclaw/agents/<name>/SOUL.md` frontmatter to find the configured `model` and `provider`. Then:
 
 - **Anthropic (Opus 4.6, Sonnet 4.6):** `echo $ANTHROPIC_API_KEY | head -c 10` — confirm key exists.
-- **GLM-5.1 / Minimax M2.7:** check `~/.openclaw/providers.json` for the base URL and hit `/v1/models` with curl.
+- **GLM-5.1 / Minimax M3:** check `~/.openclaw/providers.json` for the base URL and hit `/v1/models` with curl.
 - **Gemma 4 local:** confirm Ollama or the local runtime is up (`curl localhost:11434/api/tags`).
 
 A 401 means bad key. A 429 means you're rate limited — retry with exponential backoff or switch model. Connection refused on localhost means the local runtime crashed.


### PR DESCRIPTION
## Summary
Upgrade the `configs/minimax-m2.7` bundle (and related docs/skills) to use **MiniMax M3** as the default model. M2.7 is kept as a supported alternative for users who self-host the open weights.

## Changes
- `configs/minimax-m2.7/README.md` — retitle bundle to "M3 default", add M3 to the Model IDs table at the top (512K context, 128K max output, image input), keep `minimax-m2.7`, replace `-turbo`/`-mini` with the official `minimax-m2.7-highspeed`, update Quick Start `base-url` to `https://api.minimax.io/v1`, update Cost Comparison with M3 pricing ($0.60 / $2.40 / $0.12 cache read per M tokens), and adjust gotchas (self-hosted KV cache note now M2.7-only).
- `configs/minimax-m2.7/SOUL.md` — switch the SWE agent's `Model:` from `minimax/minimax-m2.7` to `minimax/minimax-m3`.
- `configs/minimax-m2.7/.env.example` — update default base URL and platform URL from `*.minimax.chat` to `*.minimax.io`; clarify that M3 is hosted-only today.
- `configs/README.md` — bundle table row now reads "MiniMax M3 (default) / M2.7 (229B)"; update the "which one should I pick" bullet accordingly.
- `README.md` — TOC, skills section blurb, and Model Configs table updated to surface M3.
- `TROUBLESHOOTING.md` — quick-symptoms row and the dedicated MiniMax subsection clarified: M3 is the default on the hosted API, the commercial license caveat applies only to self-hosted M2.7.
- `skills/claude/README.md`, `skills/claude/model-cost-compare/SKILL.md`, `skills/claude/openclaw-debugger/SKILL.md` — references to "Minimax M2.7" updated to "Minimax M3" (price/context row in cost-compare table refreshed to M3 numbers).

## Why
MiniMax-M3 is the latest MiniMax model — 512K context, up to 128K output, image input on both the OpenAI- and Anthropic-compatible endpoints. The hosted API is now under `api.minimax.io`. Existing M2.7 self-hosters keep working; this PR only flips the default surface in this curated list.

## Notes
- Bundle directory name `configs/minimax-m2.7/` is intentionally **unchanged** to preserve any incoming bookmarks/links from blog posts and the existing README anchors. The bundle title and contents now reflect M3 as default.
- No new sections added — only existing model IDs / descriptions / prices were updated in place.