### PR TITLE
Add clawcall — Twilio↔OpenClaw inbound phone bridge (MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Utilities and helpers for working with OpenClaw.
 | [agents.json](agents.json) | Machine-readable index of all 187 agent templates |
 | agent-validator | Validate SOUL.md syntax |
 | mcp-tester | Test MCP server connections |
+| [clawcall](https://github.com/CODEANDTRUST/clawcall) | Give your OpenClaw agent inbound phone calls (Twilio ↔ gateway voice bridge); agent tools work mid-call. |
 
 ---
 


### PR DESCRIPTION
## What this adds

**[clawcall](https://github.com/CODEANDTRUST/clawcall)** — an open-source MIT-licensed bridge that gives a self-hosted OpenClaw gateway inbound phone calls via Twilio. Added to the **Tools** table (one row, matches existing format).

## Why it fits

clawcall's key differentiator over other Twilio+OpenClaw wiring attempts is that **gateway agent tools work mid-call**. The call audio is routed through the gateway's normal agent turn pipeline (STT → `chat.send` → agent runs with full tool access → stream reply → TTS) rather than a side realtime session that bypasses tool registration. This is the architectural gap described in openclaw/openclaw#71262.

- MIT licensed, no vendor lock-in
- Works with any OpenClaw gateway version that supports the chat API
- Companion guide: [How to Give Your Self-Hosted AI Agent Inbound Phone Calls](https://www.codeandtrust.com/blog/openclaw-phone-calls)

## Checklist

- [x] Single entry in the right section (Tools — it's a bridge utility, not an agent template)
- [x] Matches existing table format (`| [Name](url) | Description |`)
- [x] Link goes to public MIT repo on GitHub
- [x] No self-promotion beyond the one-line description