### PR TITLE
Add PostEverywhere under MCP Servers (Community)

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ Model Context Protocol servers to extend agent capabilities.
 | mcp-twitter | Twitter/X posting |
 | mcp-discord | Discord bot integration |
 | mcp-linear | Linear issue tracking |
+| [PostEverywhere](https://github.com/posteverywhere/mcp) | Schedule and publish to Instagram, TikTok, YouTube, LinkedIn, Facebook, X, Threads, Pinterest, Bluesky, Discord and Telegram. Hosted MCP connector plus npm package. |
 
 ---
 


### PR DESCRIPTION
Adds **PostEverywhere** under MCP Servers (Community).

PostEverywhere is an MCP server for scheduling and publishing social posts to Instagram, TikTok, YouTube, LinkedIn, Facebook, X, Threads, Pinterest, Bluesky, Discord and Telegram. Available as a hosted connector (OAuth 2.1) at https://mcp.posteverywhere.ai/mcp and as the `@posteverywhere/mcp` npm package, with 33 tools covering posts, drafts, campaigns, bulk operations, media, analytics, webhooks, and AI captions.