### PR TITLE
Add Skill Hub - Multi-platform AI Agent Skills navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Utilities and helpers for working with OpenClaw.
 | [agents.json](agents.json) | Machine-readable index of all 187 agent templates |
 | agent-validator | Validate SOUL.md syntax |
 | mcp-tester | Test MCP server connections |
+| [Skill Hub](https://skill.442595.xyz/) | Multi-platform AI Agent Skills navigator — 577+ skills, 104 OpenClaw skills. Browse by function category. [GitHub](https://github.com/rdone4425/skill) |
 
 ---
 


### PR DESCRIPTION
## Suggestion: Add Skill Hub

**Project:** [Skill Hub](https://skill.442595.xyz/)  
**GitHub:** [rdone4425/skill](https://github.com/rdone4425/skill)
**Current Stats:** 577+ skills | 12+ platforms | 104 OpenClaw skills

### What is Skill Hub?
Skill Hub is an open-source navigation site for AI Agent Skills. It aggregates skills across multiple AI coding platforms, including 104 OpenClaw-specific skills:
- Claude Code, Codex, Cursor, OpenCode, OpenClaw, Hermes, Copilot, Gemini, MCP, and more
- 577+ curated skills organized by **function category** (Dev Tools, Design UI, Automation, Security, Testing, Data AI, Docs, Backend API, DevOps)
- Platform compatibility filtering
- Fully open source with automated data refresh

### Why add to this list?
Skill Hub is a discovery tool for OpenClaw users — browse 104 OpenClaw skills by function category. Complements this awesome list well.

### Location
Added to the `## Tools` table alongside other OpenClaw utilities.