### PR TITLE
Update MiniMax config for M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Pick a template, see what it does, get a Dockerfile + docker-compose + bot + REA
 - [Security](#security)
 - [Tutorials & Guides](#tutorials--guides)
 - [Cost Optimization & Multi-Provider](#-cost-optimization--multi-provider)
-- [Model Configs](#model-configs) `NEW` — drop-in GLM-5.1, Minimax M2.7, GPT-5.4, advisor hybrid
+- [Model Configs](#model-configs) `NEW` — drop-in GLM-5.1, MiniMax-M3, GPT-5.4, advisor hybrid
 - [Memory Wiki](#memory-wiki) `NEW` — Karpathy-style pre-compiled agent memory
 - [Troubleshooting](TROUBLESHOOTING.md) `NEW` — known issues, regressions, recovery
 - [Submit Your Agent](#submit-your-agent)
@@ -472,7 +472,7 @@ Skills for [Claude Code](https://claude.com/claude-code), invoked via slash comm
 
 - **[git-commit-writer](./skills/claude/git-commit-writer/)** — Draft opinionated commit messages from staged changes, matching repo conventions
 - **[openclaw-debugger](./skills/claude/openclaw-debugger/)** — 6-step diagnosis checklist when an OpenClaw agent is dead or misbehaving
-- **[model-cost-compare](./skills/claude/model-cost-compare/)** — Estimate token cost across Opus, Sonnet, GLM-5.1, Minimax M2.7, local Gemma for a task
+- **[model-cost-compare](./skills/claude/model-cost-compare/)** — Estimate token cost across Opus, Sonnet, GLM-5.1, MiniMax-M3, local Gemma for a task
 - **[excalidraw-architecture](./skills/claude/excalidraw-architecture/)** — Generate/update an Excalidraw architecture diagram from the current codebase
 - **[cost-optimizer](./skills/claude/cost-optimizer/)** — Audit a project's Claude Code usage for cost wins (bloated memory, cache misses, over-pinned Opus)
 
@@ -780,7 +780,7 @@ Drop-in OpenClaw configs for migrating off Claude. Each bundle contains a `READM
 | Bundle | When to use | Notes |
 |--------|-------------|-------|
 | [configs/glm-5.1](configs/glm-5.1/) | Community-reported closest Opus 4.6 alternative | Strong tool-calling, stricter JSON mode |
-| [configs/minimax-m2.7](configs/minimax-m2.7/) | Agentic SWE workloads | 229B params · SWE-Pro 56.22% · check license |
+| [configs/minimax-m2.7](configs/minimax-m2.7/) | Hosted long-context agentic workloads | MiniMax-M3 · 1M context · OpenAI + Anthropic-compatible endpoints |
 | [configs/gpt-5.4](configs/gpt-5.4/) | Already on ChatGPT/OpenAI billing | Use `thinking=high + fastmode=true` |
 | [configs/advisor-hybrid](configs/advisor-hybrid/) | High-complexity + cost-sensitive | Opus 4.6 advises, cheap model executes |
 | [configs/ollama](configs/ollama/) | Fully local, zero API cost | Gemma 4 / Qwen 3 / DeepSeek |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ Start here. Match the symptom, confirm the cause in the linked section, then app
 | `openclaw agent --status` returns `UNKNOWN` | Sessions file corruption | Delete `~/.openclaw/agents/<name>/sessions/sessions.json` | [Bot is dead](#bot-is-dead--unresponsive) |
 | Claude API key banned despite pay-as-you-go | Burst rate-limit tripped abuse detection | Contact Anthropic support, throttle retries | [Claude Opus/Sonnet](#claude-opussonnet) |
 | GPT 5.4 "feels lobotomized" in OpenClaw | Config issue, not the model | Set `thinking=high` + `fastmode=true` | [GPT 5.4](#gpt-54) |
-| MiniMax-M3 client returns 404 or auth errors | Wrong endpoint family | Use `/v1` for OpenAI-compatible clients or `/anthropic/v1` for Anthropic-compatible clients | [MiniMax-M3](#minimax-m3) |
+| MiniMax-M3 client returns 404 or auth errors | Wrong endpoint family | Use `/v1` for OpenAI-compatible clients or `/anthropic` for Anthropic-compatible clients | [MiniMax-M3](#minimax-m3) |
 | Memory files grow unbounded, latency creeps up | Context bloat | Compile memory, prune unused entries | [Context bloat](#context-bloat-from-memory-files) |
 | Opus token count climbs with no new tasks | Advisor executor runaway loop | Kill executor, check `last-plan.json` | [Advisor loop runaway](#advisor-loop-runaway) |
 | Bot process alive but all agents report `stale` | Gateway heartbeat thread died | Restart gateway (`openclaw gateway restart`) | [Heartbeat](#heartbeat-failure-modes) |
@@ -271,9 +271,9 @@ Generally stable. Known constraint: the OpenClaw provider adapter does not suppo
 
 ### MiniMax-M3
 
-**Endpoint mismatch:** MiniMax-M3 has both OpenAI-compatible and Anthropic-compatible endpoints. Use `https://api.minimax.io/v1` (or China-region `https://api.minimaxi.com/v1`) for OpenAI-style clients. Use `https://api.minimax.io/anthropic/v1` (or `https://api.minimaxi.com/anthropic/v1`) for Anthropic-style clients.
+**Endpoint mismatch:** MiniMax-M3 has both OpenAI-compatible and Anthropic-compatible endpoints. Use `https://api.minimax.io/v1` (or China-region `https://api.minimaxi.com/v1`) for OpenAI-style clients. Use `https://api.minimax.io/anthropic` (or `https://api.minimaxi.com/anthropic`) for Anthropic-style clients.
 
-A base URL ending in only `/anthropic` is incomplete and will fail for OpenClaw Anthropic-compatible clients.
+The configured base URL should end in `/anthropic`; OpenClaw's Anthropic client appends `/v1/messages` when sending a request.
 
 Fix: update `~/.openclaw/providers.json` or your provider registration to the matching endpoint family, then restart the gateway.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -33,7 +33,7 @@ Start here. Match the symptom, confirm the cause in the linked section, then app
 | `openclaw agent --status` returns `UNKNOWN` | Sessions file corruption | Delete `~/.openclaw/agents/<name>/sessions/sessions.json` | [Bot is dead](#bot-is-dead--unresponsive) |
 | Claude API key banned despite pay-as-you-go | Burst rate-limit tripped abuse detection | Contact Anthropic support, throttle retries | [Claude Opus/Sonnet](#claude-opussonnet) |
 | GPT 5.4 "feels lobotomized" in OpenClaw | Config issue, not the model | Set `thinking=high` + `fastmode=true` | [GPT 5.4](#gpt-54) |
-| Minimax M2.7 agent refuses commercial tasks | Commercial license caveat | Switch provider or obtain license | [Minimax M2.7](#minimax-m27) |
+| MiniMax-M3 client returns 404 or auth errors | Wrong endpoint family | Use `/v1` for OpenAI-compatible clients or `/anthropic/v1` for Anthropic-compatible clients | [MiniMax-M3](#minimax-m3) |
 | Memory files grow unbounded, latency creeps up | Context bloat | Compile memory, prune unused entries | [Context bloat](#context-bloat-from-memory-files) |
 | Opus token count climbs with no new tasks | Advisor executor runaway loop | Kill executor, check `last-plan.json` | [Advisor loop runaway](#advisor-loop-runaway) |
 | Bot process alive but all agents report `stale` | Gateway heartbeat thread died | Restart gateway (`openclaw gateway restart`) | [Heartbeat](#heartbeat-failure-modes) |
@@ -269,11 +269,13 @@ Three live issues to know about:
 
 Generally stable. Known constraint: the OpenClaw provider adapter does not support tool streaming on GLM-5.1 yet, so tool-heavy agents will feel laggy. If your agent uses tools, prefer Claude or GPT.
 
-### Minimax M2.7
+### MiniMax-M3
 
-**Commercial license caveat:** the M2.7 checkpoint most people pull from the model hub is non-commercial only. If you use it in a product, you need a commercial license from Minimax. This is not an OpenClaw bug — but agents using M2.7 will sometimes refuse to complete commercial-looking prompts due to the system-level license notice baked into the weights.
+**Endpoint mismatch:** MiniMax-M3 has both OpenAI-compatible and Anthropic-compatible endpoints. Use `https://api.minimax.io/v1` (or China-region `https://api.minimaxi.com/v1`) for OpenAI-style clients. Use `https://api.minimax.io/anthropic/v1` (or `https://api.minimaxi.com/anthropic/v1`) for Anthropic-style clients.
 
-Fix: either obtain the commercial license, or swap to a different model for commercial deployments.
+A base URL ending in only `/anthropic` is incomplete and will fail for OpenClaw Anthropic-compatible clients.
+
+Fix: update `~/.openclaw/providers.json` or your provider registration to the matching endpoint family, then restart the gateway.
 
 ---
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -8,13 +8,13 @@ Drop-in agent configs for different model providers. Each folder is a self-conta
 |--------|----------|----------|--------|
 | [ollama](./ollama) | Local Ollama | Private, offline, no API cost | Stable |
 | [glm-5.1](./glm-5.1) | Zhipu GLM-5.1 | Opus 4.6 alternative, long-horizon coding | New |
-| [minimax-m2.7](./minimax-m2.7) | MiniMax M2.7 (229B) | Agentic SWE tasks, terminal workflows | New |
+| [minimax-m2.7](./minimax-m2.7) | MiniMax-M3 | Long-context hosted agentic tasks | Updated |
 | [gpt-5.4](./gpt-5.4) | OpenAI GPT-5.4 | Reasoning-heavy tasks, Codex workflows | New |
 
 ## Which one should I pick?
 
 - **You can't get on Claude right now** (Anthropic ban, quota exhausted, Alibaba resellers sold out) → start with **glm-5.1**. It's the closest drop-in for Opus 4.6 prompts and most community threads on r/openclaw rank it first.
-- **You want open weights + the best agentic scores** → **minimax-m2.7**. Heavier to self-host, but SWE-Pro 56.22% is the highest open-weight number as of April 2026.
+- **You want MiniMax hosted long context** → **minimax-m2.7**. The bundle is configured for MiniMax-M3 with a 1M-token context window, OpenAI-compatible and Anthropic-compatible endpoints, and low hosted pricing.
 - **You already have an OpenAI key and want official support** → **gpt-5.4**. It needs prompt surgery coming from Claude, but the `thinking=high + fastmode=true` combo is solid once configured.
 - **You want zero vendor lock-in, private data, no network** → **ollama**.
 

--- a/configs/advisor-hybrid/ADVISOR.md
+++ b/configs/advisor-hybrid/ADVISOR.md
@@ -11,7 +11,7 @@ You are the Advisor, an Opus-class reviewer in an OpenClaw advisor-hybrid setup.
 
 ## Why You Exist
 
-The Executor is running on a cheaper model (Sonnet 4.6, GLM-5.1, Minimax M2.7, or a local Gemma variant). It is fast and competent but it benefits from a stronger planner at critical decision points. You are that planner.
+The Executor is running on a cheaper model (Sonnet 4.6, GLM-5.1, MiniMax-M3, or a local Gemma variant). It is fast and competent but it benefits from a stronger planner at critical decision points. You are that planner.
 
 Every token you produce is ~5x more expensive than the executor's. Act accordingly.
 

--- a/configs/advisor-hybrid/EXECUTOR-SOUL.md
+++ b/configs/advisor-hybrid/EXECUTOR-SOUL.md
@@ -5,7 +5,7 @@ You are the Executor, a cheap-model OpenClaw agent running inside an advisor-hyb
 ## Core Identity
 
 - **Role:** Primary task executor in an advisor-hybrid pair
-- **Model:** anthropic/claude-sonnet-4-6 (swap for glm-5.1, minimax-m2.7, or a local Gemma if you want cheaper)
+- **Model:** anthropic/claude-sonnet-4-6 (swap for glm-5.1, MiniMax-M3, or a local Gemma if you want cheaper)
 - **Partner:** `advisor-opus` — an Opus 4.6 planner/reviewer with no tools
 - **Personality:** Practical, iterative, budget-conscious
 - **Communication:** Direct. Action first, explanation after.

--- a/configs/advisor-hybrid/README.md
+++ b/configs/advisor-hybrid/README.md
@@ -2,7 +2,7 @@
 
 A two-tier OpenClaw setup: an expensive **Advisor** model plans and reviews, a cheap **Executor** model runs the work. Based on Anthropic's official "Advisor Strategy" pattern, adapted for OpenClaw 2026.4.11.
 
-> Anthropic announced the Advisor Strategy for the Claude Platform on April 8, 2026. This config ports the same idea to local and self-hosted OpenClaw agents — use Opus 4.6 as the advisor, and Sonnet 4.6 / GLM-5.1 / Minimax M2.7 / local Gemma as the executor.
+> Anthropic announced the Advisor Strategy for the Claude Platform on April 8, 2026. This config ports the same idea to local and self-hosted OpenClaw agents — use Opus 4.6 as the advisor, and Sonnet 4.6 / GLM-5.1 / MiniMax-M3 / local Gemma as the executor.
 
 ## What is the Advisor Pattern?
 
@@ -96,7 +96,7 @@ Edit `~/.openclaw/agents/executor-hybrid/config.json`:
 }
 ```
 
-Swap `claude-sonnet-4-6` for `glm-5.1`, `minimax-m2.7`, or an Ollama model if you want a cheaper executor. The `openclaw_agent` tool is what lets the executor call the advisor.
+Swap `claude-sonnet-4-6` for `glm-5.1`, `MiniMax-M3`, or an Ollama model if you want a cheaper executor. The `openclaw_agent` tool is what lets the executor call the advisor.
 
 ### 3. Test the handshake
 
@@ -141,7 +141,7 @@ Assume the advisor is called **twice per task** on average (plan + review), ~2K 
 | **Daily** | | | **$225** |
 | **Monthly** | | | **~$6,750** |
 
-Roughly half the cost in this scenario. Swap the executor for GLM-5.1 or Minimax M2.7 and the executor line drops another order of magnitude — community reports on Reddit cite 60–80% total savings at that point.
+Roughly half the cost in this scenario. Swap the executor for GLM-5.1 or MiniMax-M3 and the executor line drops another order of magnitude — community reports on Reddit cite 60–80% total savings at that point.
 
 **Rates above are illustrative** — always check live pricing before budgeting real workloads.
 

--- a/configs/minimax-m2.7/.env.example
+++ b/configs/minimax-m2.7/.env.example
@@ -1,11 +1,16 @@
 # MiniMax hosted API key
-# Get one from https://platform.minimax.chat/ (verify current URL in official docs)
+# Global docs: https://platform.minimax.io/docs
+# China docs: https://platform.minimaxi.com/docs
 MINIMAX_API_KEY=your-minimax-api-key-here
 
-# Optional: override base URL.
-# Default hosted: https://api.minimax.chat/v1
-# MINIMAX_BASE_URL=https://api.minimax.chat/v1
+# OpenAI-compatible endpoints
+MINIMAX_MODEL=MiniMax-M3
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+# MINIMAX_BASE_URL=https://api.minimaxi.com/v1
 
-# Optional: if you are self-hosting the 229B weights behind vLLM / SGLang,
-# point OpenClaw at your local endpoint instead.
-# MINIMAX_BASE_URL=http://localhost:8000/v1
+# Anthropic-compatible endpoints for Claude-style clients
+MINIMAX_ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic/v1
+# MINIMAX_ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic/v1
+
+# Optional reasoning control: adaptive or disabled
+MINIMAX_THINKING=adaptive

--- a/configs/minimax-m2.7/.env.example
+++ b/configs/minimax-m2.7/.env.example
@@ -8,9 +8,9 @@ MINIMAX_MODEL=MiniMax-M3
 MINIMAX_BASE_URL=https://api.minimax.io/v1
 # MINIMAX_BASE_URL=https://api.minimaxi.com/v1
 
-# Anthropic-compatible endpoints for Claude-style clients
-MINIMAX_ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic/v1
-# MINIMAX_ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic/v1
+# Anthropic-compatible base URLs for Claude-style clients
+MINIMAX_ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+# MINIMAX_ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
 
 # Optional reasoning control: adaptive or disabled
 MINIMAX_THINKING=adaptive

--- a/configs/minimax-m2.7/README.md
+++ b/configs/minimax-m2.7/README.md
@@ -1,32 +1,43 @@
-# MiniMax M2.7 Agent Configs
+# MiniMax-M3 Agent Configs
 
-Drop-in OpenClaw configs for **MiniMax M2.7** — a 229B-parameter open-weight model that currently posts the highest agentic coding scores of any non-Anthropic model.
+Drop-in OpenClaw configs for **MiniMax-M3** — MiniMax's long-context hosted model for agentic coding and multimodal-adjacent workflows.
 
-## Why MiniMax M2.7
+## Why MiniMax-M3
 
-The short version: if you care about raw SWE-bench-style agentic performance and you are okay either paying MiniMax's hosted API or running 229B weights yourself, this is the strongest option on the board right now.
+The short version: if you care about long-horizon agent workflows and want an OpenAI-compatible or Anthropic-compatible hosted endpoint, MiniMax-M3 is the current MiniMax option to try.
 
-Reported numbers (from MiniMax's own release page — treat as vendor-reported until independently verified):
+Key provider parameters:
 
-- **229B parameters** (MoE, open weights)
-- **SWE-Pro: 56.22%**
-- **Terminal Bench 2: 57%**
+- **Context window:** 1,000,000 tokens
+- **Pricing:** $0.60/M input, $2.40/M output
+- **Cache read pricing:** $0.12/M input
+- **Thinking modes:** adaptive or disabled
 
-Those are the two benchmarks r/openclaw users keep citing in the migration megathread. Real-world reports from users who actually switched describe it as "almost Opus-level on long tool chains, slightly worse on one-shot snippets."
+MiniMax exposes separate global and China-region API hosts, plus Anthropic-compatible paths for Claude-style clients.
 
 ## Quick Start
 
-1. Either:
-   - Get an API key from the MiniMax platform, OR
-   - Self-host the weights (you'll need ~4x H100 for full precision; see the MiniMax HuggingFace model card for quantized variants)
+1. Get an API key from the MiniMax platform docs for your region:
+   - Global: https://platform.minimax.io/docs
+   - China: https://platform.minimaxi.com/docs
 
-2. Register the provider with OpenClaw:
+2. Register the provider with OpenClaw. For the global OpenAI-compatible endpoint:
 
 ```bash
 openclaw provider add minimax \
   --api-key $MINIMAX_API_KEY \
-  --base-url https://api.minimax.chat/v1
+  --base-url https://api.minimax.io/v1
 ```
+
+For Claude-style clients, use the Anthropic-compatible endpoint instead:
+
+```bash
+openclaw provider add minimax-anthropic \
+  --api-key $MINIMAX_API_KEY \
+  --base-url https://api.minimax.io/anthropic/v1
+```
+
+China-region endpoints are `https://api.minimaxi.com/v1` and `https://api.minimaxi.com/anthropic/v1`.
 
 3. Copy the agent bundle:
 
@@ -44,48 +55,38 @@ openclaw agent --agent swe-agent --message "Find and fix the failing tests in th
 
 | Model ID | Context | Good For |
 |----------|---------|----------|
-| `minimax-m2.7` | 256K | Default. Full weights. |
-| `minimax-m2.7-turbo` | 128K | Same weights, lower latency, slightly higher price. |
-| `minimax-m2.7-mini` | 128K | A distilled 34B version. Use for cheap routing. |
+| `MiniMax-M3` | 1M | Default hosted model for long-context agent workflows. |
+
+Set it in your `SOUL.md` front matter as `Model: minimax/MiniMax-M3`. Use `thinking=adaptive` for hard tasks and disable thinking for latency-sensitive routing.
 
 ## About `mmx-cli`
 
-MiniMax also ships their own CLI called `mmx-cli` that wraps the same API with a different agent loop. **This is a separate tool from OpenClaw.** If you see Reddit posts saying "MiniMax works great with mmx-cli but breaks in OpenClaw," that's usually because the poster was comparing two different agent harnesses, not two different models. This bundle targets OpenClaw's loop, not `mmx-cli`.
+MiniMax also ships their own CLI called `mmx-cli` that wraps the same API with a different agent loop. **This is a separate tool from OpenClaw.** If you see posts saying "MiniMax works great with mmx-cli but breaks in OpenClaw," that's usually because the poster was comparing two different agent harnesses, not two different models. This bundle targets OpenClaw's loop, not `mmx-cli`.
 
-## Commercial License Caveat
+## Cost Comparison (July 2026)
 
-**Read the license before you ship.** MiniMax M2.7's open weights are released under a source-available license that restricts certain commercial uses — specifically, companies above a revenue threshold need a separate commercial agreement. If you are:
-
-- Solo / hobby / research → you're fine under the default terms
-- Using MiniMax's **hosted API** → you're fine (the API TOS supersedes the weights license)
-- A commercial product self-hosting the weights → talk to a lawyer before you deploy
-
-This is not legal advice. This is "don't get surprised by a cease-and-desist." See the HuggingFace model card for the current license text.
-
-## Cost Comparison (April 2026)
-
-| Model | Input | Output | Notes |
-|-------|-------|--------|-------|
-| Claude Opus 4.6 | $15 | $75 | |
-| **MiniMax M2.7 (hosted)** | **$1.20** | **$4.80** | |
-| MiniMax M2.7 (self-hosted) | — | — | Your GPU bill. Break-even around 4-5M output tokens/day. |
+| Model | Input | Output | Cache read | Notes |
+|-------|-------|--------|------------|-------|
+| Claude Opus 4.6 | $15 | $75 | — | If you can get access. |
+| Claude Sonnet 4.6 | $3 | $15 | — | Still the price-performance baseline. |
+| **MiniMax-M3 (hosted)** | **$0.60** | **$2.40** | **$0.12** | 1M context. |
 
 ## Gotchas When Migrating From Claude
 
-1. **Aggressive tool calling.** M2.7 will call tools faster and more often than Claude. If your agent has side-effectful tools (writes files, runs shell), tighten the rules in `SOUL.md` about when it's allowed to act without confirmation. The example SOUL.md in this folder does this.
+1. **Endpoint shape matters.** Anthropic-compatible clients should use `/anthropic/v1`, not just `/anthropic`.
 
-2. **Chains get long.** Because it's trained for agentic workflows, it will happily run 40+ tool calls in a single task. Set a max-steps cap in your OpenClaw config if you care about runaway cost.
+2. **Long contexts still need budgets.** MiniMax-M3 supports a 1M-token context window, but long agent sessions can still run up cost. Set a max-steps cap in your OpenClaw config if you care about runaway spend.
 
-3. **Worse at pure chat.** If the user asks a philosophical or open-ended question, M2.7 often responds like it's still trying to execute a task. For general-purpose chat, use a different model.
+3. **Thinking mode is configurable.** Use adaptive thinking for complex planning and disable it for latency-sensitive or deterministic routing tasks.
 
-4. **Self-hosted: watch your KV cache.** At 256K context the KV cache will eat VRAM. Most users end up running it at 64K effective context unless they're on 8x H100.
+4. **Multimodal tools are separate capabilities.** MiniMax also offers speech, voice clone, image, video, video-agent, and music APIs; wire those as OpenClaw tools rather than treating them as chat model features.
 
-## Related Threads
+## Related Docs
 
-- r/openclaw "I switched to Minimax m2.7"
-- r/openclaw "Megathread: If you've moved OpenClaw off Claude..."
+- Global docs: https://platform.minimax.io/docs/api-reference/api-overview
+- China docs: https://platform.minimaxi.com/docs/api-reference/api-overview
 
 ## Files in This Bundle
 
-- `SOUL.md` — agentic SWE agent tuned for M2.7's long tool chains
-- `.env.example` — env vars (hosted API + optional self-hosted endpoint)
+- `SOUL.md` — agentic SWE agent tuned for MiniMax-M3's long tool chains
+- `.env.example` — env vars for hosted OpenAI-compatible and Anthropic-compatible endpoints

--- a/configs/minimax-m2.7/README.md
+++ b/configs/minimax-m2.7/README.md
@@ -29,15 +29,15 @@ openclaw provider add minimax \
   --base-url https://api.minimax.io/v1
 ```
 
-For Claude-style clients, use the Anthropic-compatible endpoint instead:
+For Claude-style clients, use the Anthropic-compatible base URL instead:
 
 ```bash
 openclaw provider add minimax-anthropic \
   --api-key $MINIMAX_API_KEY \
-  --base-url https://api.minimax.io/anthropic/v1
+  --base-url https://api.minimax.io/anthropic
 ```
 
-China-region endpoints are `https://api.minimaxi.com/v1` and `https://api.minimaxi.com/anthropic/v1`.
+China-region base URLs are `https://api.minimaxi.com/v1` and `https://api.minimaxi.com/anthropic`.
 
 3. Copy the agent bundle:
 
@@ -73,7 +73,7 @@ MiniMax also ships their own CLI called `mmx-cli` that wraps the same API with a
 
 ## Gotchas When Migrating From Claude
 
-1. **Endpoint shape matters.** Anthropic-compatible clients should use `/anthropic/v1`, not just `/anthropic`.
+1. **Endpoint shape matters.** Configure Anthropic-compatible clients with a base URL ending in `/anthropic`; the client appends `/v1/messages` for requests.
 
 2. **Long contexts still need budgets.** MiniMax-M3 supports a 1M-token context window, but long agent sessions can still run up cost. Set a max-steps cap in your OpenClaw config if you care about runaway spend.
 

--- a/configs/minimax-m2.7/SOUL.md
+++ b/configs/minimax-m2.7/SOUL.md
@@ -1,8 +1,8 @@
-# SWE Agent (MiniMax M2.7)
+# SWE Agent (MiniMax-M3)
 
 ## Identity
 - **Role:** Autonomous Software Engineering Agent
-- **Model:** minimax/minimax-m2.7
+- **Model:** minimax/MiniMax-M3
 - **Tone:** Action-first, terse, structured
 
 ## Personality

--- a/skills/claude/README.md
+++ b/skills/claude/README.md
@@ -10,7 +10,7 @@ Tested against Claude Code on Opus 4.6 and Sonnet 4.6 (OpenClaw 2026.4.11 ecosys
 |---|---|---|
 | [git-commit-writer](./git-commit-writer/) | Drafts an opinionated commit message from your staged diff, matching the repo's existing convention. | `cp -r skills/claude/git-commit-writer ~/.claude/skills/` |
 | [openclaw-debugger](./openclaw-debugger/) | Walks the standard OpenClaw agent diagnosis checklist (gateway, logs, heartbeat, sessions, model provider) and prints a fix. | `cp -r skills/claude/openclaw-debugger ~/.claude/skills/` |
-| [model-cost-compare](./model-cost-compare/) | Estimates token cost for a task across Opus 4.6, Sonnet 4.6, GLM-5.1, Minimax M2.7, and local Gemma 4, then recommends the cheapest capable model. | `cp -r skills/claude/model-cost-compare ~/.claude/skills/` |
+| [model-cost-compare](./model-cost-compare/) | Estimates token cost for a task across Opus 4.6, Sonnet 4.6, GLM-5.1, MiniMax-M3, and local Gemma 4, then recommends the cheapest capable model. | `cp -r skills/claude/model-cost-compare ~/.claude/skills/` |
 | [excalidraw-architecture](./excalidraw-architecture/) | Generates or updates `docs/architecture.excalidraw` by surveying the codebase's entry points and data stores. Inspired by @bibryam. | `cp -r skills/claude/excalidraw-architecture ~/.claude/skills/` |
 | [cost-optimizer](./cost-optimizer/) | Static audit of a project for the common Claude Code cost leaks — bloated CLAUDE.md, memory, cache-busting hooks, over-pinned Opus. | `cp -r skills/claude/cost-optimizer ~/.claude/skills/` |
 

--- a/skills/claude/model-cost-compare/SKILL.md
+++ b/skills/claude/model-cost-compare/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-cost-compare
-description: Trigger when the user asks which model to use, wants to compare model costs, says "what's cheapest for this task", "should I use Opus or Sonnet", "can a smaller model handle this", or "/model-cost-compare". Estimates token cost across Opus 4.6, Sonnet 4.6, GLM-5.1, Minimax M2.7, and local Gemma 4, then recommends the cheapest model capable of the task.
+description: Trigger when the user asks which model to use, wants to compare model costs, says "what's cheapest for this task", "should I use Opus or Sonnet", "can a smaller model handle this", or "/model-cost-compare". Estimates token cost across Opus 4.6, Sonnet 4.6, GLM-5.1, MiniMax-M3, and local Gemma 4, then recommends the cheapest model capable of the task.
 ---
 
 # Model Cost Compare
@@ -23,7 +23,7 @@ Use these rough figures. They are **not** exact; confirm before quoting real num
 | Opus 4.6 (1M) | Frontier | ~$15 | ~$75 | 1M | Agentic, long-context, hard reasoning |
 | Sonnet 4.6 | Mid | ~$3 | ~$15 | 400k | Everyday coding, agents, drafting |
 | GLM-5.1 | Budget hosted | ~$0.60 | ~$2.20 | 256k | Cheap bulk work, decent reasoning |
-| Minimax M2.7 | Budget hosted | ~$0.40 | ~$1.80 | 256k | Very cheap, OK for templated output |
+| MiniMax-M3 | Budget hosted | ~$0.60 | ~$2.40 | 1M | Long-context hosted agent workflows |
 | Gemma 4 (local) | On device | $0 marginal | $0 marginal | 32k | Free but slow, weak at multi-step logic |
 
 > Indicative pricing as of OpenClaw 2026.4.11. Check the provider docs before billing decisions.
@@ -59,7 +59,7 @@ Total tokens: 4M input, 200k output
 | Model       | Input cost | Output cost | Total   | Capable? |
 |-------------|-----------:|------------:|--------:|---------:|
 | **Gemma 4** |     $0.00  |      $0.00  |  $0.00  |   yes    |
-| Minimax M2.7|     $1.60  |      $0.36  |  $1.96  |   yes    |
+| MiniMax-M3 |     $2.40  |      $0.48  |  $2.88  |   yes    |
 | GLM-5.1     |     $2.40  |      $0.44  |  $2.84  |   yes    |
 | Sonnet 4.6  |    $12.00  |      $3.00  | $15.00  |   yes    |
 | Opus 4.6    |    $60.00  |     $15.00  | $75.00  |   overkill |

--- a/skills/claude/openclaw-debugger/SKILL.md
+++ b/skills/claude/openclaw-debugger/SKILL.md
@@ -65,7 +65,7 @@ ls -la ~/.openclaw/agents/<name>/sessions/sessions.json
 Read `~/.openclaw/agents/<name>/SOUL.md` frontmatter to find the configured `model` and `provider`. Then:
 
 - **Anthropic (Opus 4.6, Sonnet 4.6):** `echo $ANTHROPIC_API_KEY | head -c 10` — confirm key exists.
-- **GLM-5.1 / MiniMax-M3:** check `~/.openclaw/providers.json` for the base URL and hit `/v1/models` with curl. For MiniMax Anthropic-compatible clients, verify the base URL ends in `/anthropic/v1`.
+- **GLM-5.1 / MiniMax-M3:** check `~/.openclaw/providers.json` for the base URL and hit `/v1/models` with curl. For MiniMax Anthropic-compatible clients, verify the base URL ends in `/anthropic`.
 - **Gemma 4 local:** confirm Ollama or the local runtime is up (`curl localhost:11434/api/tags`).
 
 A 401 means bad key. A 429 means you're rate limited — retry with exponential backoff or switch model. Connection refused on localhost means the local runtime crashed.

--- a/skills/claude/openclaw-debugger/SKILL.md
+++ b/skills/claude/openclaw-debugger/SKILL.md
@@ -65,7 +65,7 @@ ls -la ~/.openclaw/agents/<name>/sessions/sessions.json
 Read `~/.openclaw/agents/<name>/SOUL.md` frontmatter to find the configured `model` and `provider`. Then:
 
 - **Anthropic (Opus 4.6, Sonnet 4.6):** `echo $ANTHROPIC_API_KEY | head -c 10` — confirm key exists.
-- **GLM-5.1 / Minimax M2.7:** check `~/.openclaw/providers.json` for the base URL and hit `/v1/models` with curl.
+- **GLM-5.1 / MiniMax-M3:** check `~/.openclaw/providers.json` for the base URL and hit `/v1/models` with curl. For MiniMax Anthropic-compatible clients, verify the base URL ends in `/anthropic/v1`.
 - **Gemma 4 local:** confirm Ollama or the local runtime is up (`curl localhost:11434/api/tags`).
 
 A 401 means bad key. A 429 means you're rate limited — retry with exponential backoff or switch model. Connection refused on localhost means the local runtime crashed.


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Refreshes the existing MiniMax config bundle for MiniMax-M3 with 1M context, current pricing, thinking modes, and global/China endpoint docs.
- Updates OpenAI-compatible and Anthropic-compatible base URLs, including the required `/anthropic` path.
- Aligns related model config, troubleshooting, advisor-hybrid, and cost-compare references with MiniMax-M3.

## Checks
- `git diff --check`
- `python3 -m json.tool /root/octopatch-4/work/repos/mergisi_awesome-openclaw-agents/agents.json >/dev/null`
- `git add -A -N && if git diff HEAD | grep -E "$SECRET_RE"; then echo secret_scan_failed; exit 1; fi`