### PR TITLE
Add mcpqueen to Community MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ Model Context Protocol servers to extend agent capabilities.
 | mcp-twitter | Twitter/X posting |
 | mcp-discord | Discord bot integration |
 | mcp-linear | Linear issue tracking |
+| [mcpqueen](https://github.com/mcpqueen/mcpqueen) | Graded MCP registry — search evidence-backed grades to find a working MCP for a task before you connect. Remote: `npx -y mcp-remote https://mcpqueen.com/mcp` |
 
 ---
 


### PR DESCRIPTION
Adds **mcpqueen** ([mcpqueen.com](https://mcpqueen.com)) to the Community MCP servers table.

**What it is:** a graded MCP registry — it crawls the official MCP registry, probes every remote server live over streamable HTTP, and grades each one deterministically with verbatim evidence (reachability / protocol / tooling / latency / provenance). No stars, no votes, no pay-to-rank.

**Why it's useful in OpenClaw:** it's itself a remote, no-auth, read-only MCP server, so an agent can keep it connected and call `search_servers` / `search_tools` to find a *working, graded* MCP for a task before committing to one.

**Connect (any stdio client, incl. OpenClaw):**
```json
{ "mcpServers": { "mcpqueen": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcpqueen.com/mcp"] } } }
```

Placed in **Community** (not Official, since it's not an Anthropic server). One row, matching the existing table format.