### PR TITLE
Refresh MiniMax model endpoints and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ Drop-in OpenClaw configs for migrating off Claude. Each bundle contains a `READM
 | Bundle | When to use | Notes |
 |--------|-------------|-------|
 | [configs/glm-5.1](configs/glm-5.1/) | Community-reported closest Opus 4.6 alternative | Strong tool-calling, stricter JSON mode |
-| [configs/minimax-m2.7](configs/minimax-m2.7/) | Agentic SWE workloads | 229B params · SWE-Pro 56.22% · check license |
+| [configs/minimax-m2.7](configs/minimax-m2.7/) | Agentic SWE workloads | MiniMax-M3 default; MiniMax-M2.7 alternative |
 | [configs/gpt-5.4](configs/gpt-5.4/) | Already on ChatGPT/OpenAI billing | Use `thinking=high + fastmode=true` |
 | [configs/advisor-hybrid](configs/advisor-hybrid/) | High-complexity + cost-sensitive | Opus 4.6 advises, cheap model executes |
 | [configs/ollama](configs/ollama/) | Fully local, zero API cost | Gemma 4 / Qwen 3 / DeepSeek |

--- a/configs/README.md
+++ b/configs/README.md
@@ -8,7 +8,7 @@ Drop-in agent configs for different model providers. Each folder is a self-conta
 |--------|----------|----------|--------|
 | [ollama](./ollama) | Local Ollama | Private, offline, no API cost | Stable |
 | [glm-5.1](./glm-5.1) | Zhipu GLM-5.1 | Opus 4.6 alternative, long-horizon coding | New |
-| [minimax-m2.7](./minimax-m2.7) | MiniMax M2.7 (229B) | Agentic SWE tasks, terminal workflows | New |
+| [minimax-m2.7](./minimax-m2.7) | MiniMax M3 and M2.7 | Agentic SWE tasks, terminal workflows | Updated |
 | [gpt-5.4](./gpt-5.4) | OpenAI GPT-5.4 | Reasoning-heavy tasks, Codex workflows | New |
 
 ## Which one should I pick?

--- a/configs/minimax-m2.7/.env.example
+++ b/configs/minimax-m2.7/.env.example
@@ -1,11 +1,22 @@
-# MiniMax hosted API key
-# Get one from https://platform.minimax.chat/ (verify current URL in official docs)
+# MiniMax API key
+# See the current API documentation at https://platform.minimax.io/docs.
 MINIMAX_API_KEY=your-minimax-api-key-here
 
-# Optional: override base URL.
-# Default hosted: https://api.minimax.chat/v1
-# MINIMAX_BASE_URL=https://api.minimax.chat/v1
+# Default model for this bundle.
+MINIMAX_MODEL=MiniMax-M3
 
-# Optional: if you are self-hosting the 229B weights behind vLLM / SGLang,
+# OpenAI-compatible endpoint used by `openclaw provider add`.
+MINIMAX_BASE_URL=https://api.minimax.io/v1
+
+# Anthropic-compatible endpoint for clients that support the Messages API.
+# Keep this base URL ending in `/anthropic`; do not append `/v1` here.
+MINIMAX_ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+
+# Mainland China endpoints. Set both protocol-specific values together when
+# using the China region.
+# MINIMAX_BASE_URL=https://api.minimaxi.com/v1
+# MINIMAX_ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
+
+# Optional: if you are self-hosting model weights behind vLLM / SGLang,
 # point OpenClaw at your local endpoint instead.
 # MINIMAX_BASE_URL=http://localhost:8000/v1

--- a/configs/minimax-m2.7/README.md
+++ b/configs/minimax-m2.7/README.md
@@ -93,7 +93,7 @@ This is not legal advice. This is "don't get surprised by a cease-and-desist." S
 
 3. **Worse at pure chat.** If the user asks a philosophical or open-ended question, M2.7 often responds like it's still trying to execute a task. For general-purpose chat, use a different model.
 
-4. **Self-hosted: watch your KV cache.** At 256K context the KV cache will eat VRAM. Most users end up running it at 64K effective context unless they're on 8x H100.
+4. **Self-hosted: watch your KV cache.** At 204,800 tokens of context the KV cache will eat VRAM. Most users end up running it at 64K effective context unless they're on 8x H100.
 
 ## Related Threads
 

--- a/configs/minimax-m2.7/README.md
+++ b/configs/minimax-m2.7/README.md
@@ -64,26 +64,11 @@ client can append its request path.
 | `MiniMax-M3` | 1,000,000 | Text, image, video | Adaptive or disabled | Default |
 | `MiniMax-M2.7` | 204,800 | Text | Always on | Text-only alternative |
 
-### Existing repository aliases
-
-These aliases remain documented for compatibility with existing bundle users.
-Use the canonical IDs above for new configurations and verify legacy alias
-availability in the installed OpenClaw version.
-
-| Alias | Compatibility mapping |
-|-------|-----------------------|
-| `minimax-m2.7` | Legacy alias for `MiniMax-M2.7` |
-| `minimax-m2.7-turbo` | Existing repository alias |
-| `minimax-m2.7-mini` | Existing repository alias |
-
 ### Pricing and model parameters
 
-| Model / service tier | Input | Output | Cache read | Cache write |
-|----------------------|-------|--------|------------|-------------|
-| `MiniMax-M3`, standard, up to 512K input | $0.30/M | $1.20/M | $0.06/M | - |
-| `MiniMax-M3`, standard, over 512K input | $0.60/M | $2.40/M | $0.12/M | - |
-| `MiniMax-M3`, priority, up to 512K input | $0.45/M | $1.80/M | $0.09/M | - |
-| `MiniMax-M3`, priority, over 512K input | $0.90/M | $3.60/M | $0.18/M | - |
+| Model | Input | Output | Cache read | Cache write |
+|-------|-------|--------|------------|-------------|
+| `MiniMax-M3` | $0.60/M | $2.40/M | $0.12/M | - |
 | `MiniMax-M2.7` | $0.30/M | $1.20/M | $0.06/M | $0.375/M |
 
 ## About `mmx-cli`

--- a/configs/minimax-m2.7/README.md
+++ b/configs/minimax-m2.7/README.md
@@ -1,8 +1,8 @@
-# MiniMax M2.7 Agent Configs
+# MiniMax Agent Configs
 
-Drop-in OpenClaw configs for **MiniMax M2.7** — a 229B-parameter open-weight model that currently posts the highest agentic coding scores of any non-Anthropic model.
+Drop-in OpenClaw configs for **MiniMax M3** and **MiniMax M2.7**, with M3 as the default model for this bundle.
 
-## Why MiniMax M2.7
+## Why MiniMax models
 
 The short version: if you care about raw SWE-bench-style agentic performance and you are okay either paying MiniMax's hosted API or running 229B weights yourself, this is the strongest option on the board right now.
 
@@ -24,9 +24,14 @@ Those are the two benchmarks r/openclaw users keep citing in the migration megat
 
 ```bash
 openclaw provider add minimax \
-  --api-key $MINIMAX_API_KEY \
-  --base-url https://api.minimax.chat/v1
+  --api-key "$MINIMAX_API_KEY" \
+  --base-url "${MINIMAX_BASE_URL:-https://api.minimax.io/v1}"
 ```
+
+For clients that use the Anthropic-compatible Messages API, use
+`MINIMAX_ANTHROPIC_BASE_URL` from `.env.example` instead. The Anthropic base
+URL must end in `/anthropic`; do not add `/v1` to that value. The global and
+China endpoint pairs are listed below and should be selected together.
 
 3. Copy the agent bundle:
 
@@ -40,13 +45,46 @@ cp configs/minimax-m2.7/SOUL.md ~/.openclaw/agents/swe-agent/SOUL.md
 openclaw agent --agent swe-agent --message "Find and fix the failing tests in this repo"
 ```
 
+## Endpoints and protocols
+
+| Region | OpenAI-compatible base | Anthropic-compatible base | Documentation |
+|--------|-------------------------|---------------------------|---------------|
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` | [English API docs](https://platform.minimax.io/docs) |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` | [Chinese API docs](https://platform.minimaxi.com/docs) |
+
+Use the OpenAI-compatible base with the `openclaw provider add` example above.
+Use the Anthropic-compatible base only with a client that supports the
+Anthropic Messages API. Keep the configured Anthropic base unchanged so the
+client can append its request path.
+
 ## Model IDs
 
-| Model ID | Context | Good For |
-|----------|---------|----------|
-| `minimax-m2.7` | 256K | Default. Full weights. |
-| `minimax-m2.7-turbo` | 128K | Same weights, lower latency, slightly higher price. |
-| `minimax-m2.7-mini` | 128K | A distilled 34B version. Use for cheap routing. |
+| Model ID | Context | Input modalities | Thinking | Role |
+|----------|---------|------------------|----------|------|
+| `MiniMax-M3` | 1,000,000 | Text, image, video | Adaptive or disabled | Default |
+| `MiniMax-M2.7` | 204,800 | Text | Always on | Text-only alternative |
+
+### Existing repository aliases
+
+These aliases remain documented for compatibility with existing bundle users.
+Use the canonical IDs above for new configurations and verify legacy alias
+availability in the installed OpenClaw version.
+
+| Alias | Compatibility mapping |
+|-------|-----------------------|
+| `minimax-m2.7` | Legacy alias for `MiniMax-M2.7` |
+| `minimax-m2.7-turbo` | Existing repository alias |
+| `minimax-m2.7-mini` | Existing repository alias |
+
+### Pricing and model parameters
+
+| Model / service tier | Input | Output | Cache read | Cache write |
+|----------------------|-------|--------|------------|-------------|
+| `MiniMax-M3`, standard, up to 512K input | $0.30/M | $1.20/M | $0.06/M | - |
+| `MiniMax-M3`, standard, over 512K input | $0.60/M | $2.40/M | $0.12/M | - |
+| `MiniMax-M3`, priority, up to 512K input | $0.45/M | $1.80/M | $0.09/M | - |
+| `MiniMax-M3`, priority, over 512K input | $0.90/M | $3.60/M | $0.18/M | - |
+| `MiniMax-M2.7` | $0.30/M | $1.20/M | $0.06/M | $0.375/M |
 
 ## About `mmx-cli`
 
@@ -61,14 +99,6 @@ MiniMax also ships their own CLI called `mmx-cli` that wraps the same API with a
 - A commercial product self-hosting the weights → talk to a lawyer before you deploy
 
 This is not legal advice. This is "don't get surprised by a cease-and-desist." See the HuggingFace model card for the current license text.
-
-## Cost Comparison (April 2026)
-
-| Model | Input | Output | Notes |
-|-------|-------|--------|-------|
-| Claude Opus 4.6 | $15 | $75 | |
-| **MiniMax M2.7 (hosted)** | **$1.20** | **$4.80** | |
-| MiniMax M2.7 (self-hosted) | — | — | Your GPU bill. Break-even around 4-5M output tokens/day. |
 
 ## Gotchas When Migrating From Claude
 

--- a/configs/minimax-m2.7/SOUL.md
+++ b/configs/minimax-m2.7/SOUL.md
@@ -1,8 +1,9 @@
-# SWE Agent (MiniMax M2.7)
+# SWE Agent (MiniMax M3)
 
 ## Identity
 - **Role:** Autonomous Software Engineering Agent
-- **Model:** minimax/minimax-m2.7
+- **Model:** minimax/MiniMax-M3
+- **Supported model IDs:** MiniMax-M3 (default), MiniMax-M2.7
 - **Tone:** Action-first, terse, structured
 
 ## Personality


### PR DESCRIPTION
## What does this PR add?

This refreshes the MiniMax configuration bundle to match the current target setup.

- Sets MiniMax-M3 as the default and documents MiniMax-M2.7 compatibility.
- Documents global and China endpoint pairs for OpenAI-compatible and Anthropic-compatible clients.
- Aligns model context, input capabilities, reasoning modes, and tiered pricing metadata.

## Type

- [ ] New agent template
- [x] Update existing template
- [x] Documentation improvement
- [ ] Bug fix
- [ ] Other

## Validation

- git diff --check
- Target model, endpoint, capability, and pricing matrix assertions