### PR TITLE
Bundle a music generation integration for music_generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Skills for [Claude Code](https://claude.com/claude-code), invoked via slash comm
 - **[model-cost-compare](./skills/claude/model-cost-compare/)** — Estimate token cost across Opus, Sonnet, GLM-5.1, Minimax M2.7, local Gemma for a task
 - **[excalidraw-architecture](./skills/claude/excalidraw-architecture/)** — Generate/update an Excalidraw architecture diagram from the current codebase
 - **[cost-optimizer](./skills/claude/cost-optimizer/)** — Audit a project's Claude Code usage for cost wins (bloated memory, cache misses, over-pinned Opus)
+- **[music-generate](./skills/claude/music-generate/)** — Produce background tracks, jingles, instrumentals, songs from lyrics, or covers with the bundled `music_generate` integration
 
 **[Browse all skills →](./skills/)**
 

--- a/agents/creative/music-producer/SOUL.md
+++ b/agents/creative/music-producer/SOUL.md
@@ -25,7 +25,7 @@ You are a music producer who creates background tracks, jingles, and soundscapes
 - Never copy or closely imitate copyrighted melodies
 
 ## Integrations
-- music_generate: Core tool for producing audio tracks
+- music_generate: Core tool for producing audio tracks. The bundled integration in `skills/claude/music-generate/SKILL.md` documents the global and China endpoints, the request fields, and the response mapping this tool expects.
 - Telegram: Share audio previews for quick feedback
 - GitHub: Version-control music briefs and project configs
 

--- a/skills/claude/README.md
+++ b/skills/claude/README.md
@@ -13,6 +13,7 @@ Tested against Claude Code on Opus 4.6 and Sonnet 4.6 (OpenClaw 2026.4.11 ecosys
 | [model-cost-compare](./model-cost-compare/) | Estimates token cost for a task across Opus 4.6, Sonnet 4.6, GLM-5.1, Minimax M2.7, and local Gemma 4, then recommends the cheapest capable model. | `cp -r skills/claude/model-cost-compare ~/.claude/skills/` |
 | [excalidraw-architecture](./excalidraw-architecture/) | Generates or updates `docs/architecture.excalidraw` by surveying the codebase's entry points and data stores. Inspired by @bibryam. | `cp -r skills/claude/excalidraw-architecture ~/.claude/skills/` |
 | [cost-optimizer](./cost-optimizer/) | Static audit of a project for the common Claude Code cost leaks — bloated CLAUDE.md, memory, cache-busting hooks, over-pinned Opus. | `cp -r skills/claude/cost-optimizer ~/.claude/skills/` |
+| [music-generate](./music-generate/) | Generates a background track, jingle, instrumental, song from lyrics, or cover of an existing recording — bundles the endpoint, request fields, and response mapping behind `music_generate`. | `cp -r skills/claude/music-generate ~/.claude/skills/` |
 
 ## How invocation works
 

--- a/skills/claude/music-generate/SKILL.md
+++ b/skills/claude/music-generate/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: music-generate
+description: Trigger when the user asks for generated music, a background track, a jingle, an intro or outro sting, an instrumental bed, a song from supplied lyrics, or a cover of an existing recording, or says "/music-generate". Calls the MiniMax music generation endpoint and writes the returned audio to a file.
+---
+
+# Music Generate
+
+Bundled integration for the MiniMax music generation endpoint. This is the concrete request and
+response contract behind the `music_generate` capability referenced by the
+[Music Producer](../../../agents/creative/music-producer/SOUL.md) template, so an agent can produce a
+track with one HTTP call instead of depending on a separate command line tool.
+
+## When to use
+
+- "Generate background music for this video"
+- "Make a 5 second jingle for our podcast intro"
+- "Turn these lyrics into a song"
+- "I need an instrumental ambient bed"
+- "Make a cover of this recording"
+- `/music-generate <brief>`
+
+## Setup
+
+```bash
+# API key for your account
+export MINIMAX_API_KEY=your-api-key-here
+
+# Pick the endpoint for your service region
+export MINIMAX_MUSIC_URL=https://api.minimax.io/v1/music_generation   # global
+# export MINIMAX_MUSIC_URL=https://api.minimaxi.com/v1/music_generation   # mainland China
+```
+
+## Endpoints
+
+| Region | Endpoint | Documentation |
+|---|---|---|
+| Global | `https://api.minimax.io/v1/music_generation` | [API reference](https://platform.minimax.io/docs/api-reference/music-generation) |
+| Mainland China | `https://api.minimaxi.com/v1/music_generation` | [API reference](https://platform.minimaxi.com/docs/api-reference/music-generation) |
+
+Both regions expose the same `generateMusic` operation over `POST` with an
+`Authorization: Bearer <key>` header and a `Content-Type: application/json` body.
+Accounts are region-scoped: use the key issued for the region whose endpoint you call.
+
+## Models
+
+| Task | Model IDs |
+|---|---|
+| Text to music | `music-3.0` (default), `music-2.6`, `music-3.0-free`, `music-2.6-free` |
+| Cover an existing recording | `music-cover`, `music-cover-free` |
+
+Use `music-3.0` unless the user asks for something else. The `-free` variants run the same
+interface at a much lower rate limit, so prefer them only for a smoke test.
+
+## Request fields
+
+| Field | Notes |
+|---|---|
+| `model` | **Required.** One of the model IDs above. |
+| `prompt` | Style, mood, instrumentation, and scenario. Required for instrumental text-to-music and for the cover models. |
+| `lyrics` | Lyric lines separated by `\n`. Required for vocal text-to-music. Section tags such as `[Intro]`, `[Verse]`, `[Chorus]`, `[Bridge]`, `[Outro]` are supported. |
+| `stream` | Boolean, defaults to `false`. Streamed responses accept only `output_format: hex`. |
+| `output_format` | `url` / `hex`. `hex` returns the audio inline as a hex string; `url` returns a link that expires after 24 hours. |
+| `audio_setting` | Object controlling the rendered file. See the table below. |
+| `lyrics_optimizer` | Boolean, defaults to `false`. Writes lyrics from `prompt` when `lyrics` is empty. Text-to-music models only. |
+| `is_instrumental` | Boolean, defaults to `false`. Produces a vocal-free track, so `lyrics` is not needed. Text-to-music models only. |
+| `audio_url` | Cover models only. Link to the reference recording. |
+| `audio_base64` | Cover models only. The same recording inlined as base64. |
+| `cover_feature_id` | Cover models only. Reuses a previously preprocessed reference instead of re-uploading audio. |
+
+`audio_setting` sub-fields:
+
+| Sub-field | Type | Allowed values |
+|---|---|---|
+| `sample_rate` | integer | `16000`, `24000`, `32000`, `44100` |
+| `bitrate` | integer | `32000`, `64000`, `128000`, `256000` |
+| `format` | string | `mp3` / `wav` / `pcm` |
+
+### Cover input rules
+
+- Supply exactly one of `audio_url` or `audio_base64`, or a `cover_feature_id` from a previous
+  preprocess call. Sending more than one is rejected.
+- The reference recording must run between 6 and 360 seconds and stay under 50 MB.
+
+### Region-specific fields
+
+- `aigc_watermark` is accepted only by the mainland China endpoint. Do not send it to the
+  global endpoint, which rejects unknown fields.
+
+## Response mapping
+
+| What you need | Where it is |
+|---|---|
+| Call succeeded | `base_resp.status_code` equals `0`; anything else is an error, and `base_resp.status_msg` carries the reason |
+| Generation finished | `data.status` equals `2` (`1` means still rendering) |
+| Audio payload | `data.audio` |
+
+The call is synchronous: there is no task id and no separate query endpoint, so never poll.
+Check `base_resp.status_code` first, then `data.status`, then read the audio out of `data.audio`.
+With `output_format: hex` the value in `data.audio` is hex text that you decode to bytes yourself;
+with `output_format: url` it is a link that expires after 24 hours, so download it immediately.
+
+## Instructions
+
+1. Ask for mood, genre, tempo, and intended length before the first call unless the user
+   already gave them. One clarifying round, then generate.
+2. Build the body: `model`, a descriptive `prompt`, and either `lyrics` or
+   `is_instrumental: true`. Set `lyrics_optimizer: true` only when the user wants vocals but
+   has no lyrics.
+3. Send the request:
+
+```bash
+curl -sS "$MINIMAX_MUSIC_URL" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "music-3.0",
+    "prompt": "warm electronic synth bed, 120 BPM, building energy, product launch",
+    "is_instrumental": true,
+    "output_format": "hex",
+    "audio_setting": {"sample_rate": 44100, "bitrate": 256000, "format": "mp3"}
+  }' > response.json
+```
+
+4. Verify the call, then decode the track:
+
+```bash
+python3 -c "import json;d=json.load(open('response.json'));\
+assert d['base_resp']['status_code'] == 0, d['base_resp']['status_msg'];\
+assert d['data']['status'] == 2, 'still rendering';\
+open('track.mp3','wb').write(bytes.fromhex(d['data']['audio']))"
+```
+
+5. Report the saved path, the model used, and the audio settings. When the user asked for
+   variations, change one dimension at a time (tempo, instrumentation, energy) and keep the
+   rest of the body identical so the results stay comparable.
+
+## Rules
+
+- Never echo the API key, and never paste it into the request body.
+- Keep `prompt` descriptive rather than naming a copyrighted work to imitate.
+- Match `audio_setting.format` to the delivery target: `mp3` for general sharing,
+  `wav` for further editing, `pcm` for raw pipelines.
+- For streaming set `stream: true` and `output_format: hex`; the other output format is not
+  available while streaming.
+
+## Example invocations
+
+- `/music-generate 45s inspiring synth bed for a product launch video`
+- "Make me a 5 second podcast intro jingle, bright and acoustic"
+- "Sing these lyrics as a slow ballad"


### PR DESCRIPTION
Reason: The `music_generate` capability referenced by the Music Producer template has no bundled integration in this repository, so the endpoint, request body, and response handling are left to an external tool.

## What this changes

Adds `skills/claude/music-generate/SKILL.md`, a bundled music generation integration that follows the format documented in `skills/claude/README.md` (frontmatter with `name` + `description`, folder name matching `name`, 150 lines).

It documents the contract an agent needs to make the call itself:

- **Both service regions** — the global endpoint and the mainland China endpoint, in a table with the matching API reference link for each, plus the note that keys are region-scoped.
- **Model IDs** — the text-to-music models with the default called out, and the cover models listed separately.
- **Full request field set** — `model` (required), `prompt`, `lyrics`, `stream`, `output_format`, `audio_setting`, `lyrics_optimizer`, `is_instrumental`, `audio_url`, `audio_base64`, `cover_feature_id`, with the `audio_setting` sub-fields (`sample_rate`, `bitrate`, `format`) and their allowed values.
- **Output and audio formats** — the two output formats, the 24-hour link expiry, the streaming restriction to a single output format, and the three audio formats mapped to delivery targets.
- **Cover input rules** — exactly one of the two audio inputs or a preprocessed feature id, with the duration and size limits on the reference recording.
- **Region-specific field** — the field accepted only by the mainland China endpoint.
- **Response mapping** — success code, the in-progress and completed status values, where the audio payload lives, and the fact that the call is synchronous so there is no task id and nothing to poll.
- A worked request and a decode step that turns the returned hex payload into an audio file.

Registry wiring, following the contribution steps in `skills/claude/README.md`:

- Row added to the skills table in `skills/claude/README.md`.
- Bullet added to the skills list in `README.md`.
- The `music_generate` line in `agents/creative/music-producer/SOUL.md` now points at the bundled integration instead of naming a tool with no documented contract.

No agent templates were added, so `agents.json` is unchanged.

## Checks

This repository has no build or test harness, so the checks were run against the changed files directly:

- Skill frontmatter parses, exposes only `name` and `description`, the folder name matches `name`, and the file length is inside the 80-200 line convention stated in `skills/claude/README.md`.
- Every relative link in the four changed files resolves. Compared against `origin/main`: the 19 broken links in `README.md` are pre-existing and this branch introduces none.
- `bash -n` is clean on all three embedded bash blocks.
- The embedded Python snippet compiles, and the request body in the example parses as JSON.
- Replayed the documented response mapping against a synthetic response: the success code and status assertions pass and the hex payload decodes back to the original bytes.
- `agents.json` still parses.
