### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ Want to request an agent instead? Use the [Agent Request](https://github.com/mer
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mergisi/awesome-openclaw-agents&type=Date)](https://star-history.com/#mergisi/awesome-openclaw-agents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mergisi/awesome-openclaw-agents&type=Date)](https://star-history.dera.page/#mergisi/awesome-openclaw-agents&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions on the upstream service. This change routes the chart and its link to a working mirror so the project's growth remains visible. No other content is modified.