### PR TITLE
Add awesome-agentic-ai as a related hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ Want to request an agent instead? Use the [Agent Request](https://github.com/mer
 - [🦞 CrewClaw](https://crewclaw.com) - Deploy AI agents with zero config. No Docker, no terminal.
 - [OpenClaw](https://github.com/openclaw) - Official OpenClaw repository
 - [Anthropic MCP](https://github.com/anthropics/mcp) - Model Context Protocol
+- [awesome-agentic-ai](https://github.com/adriannoes/awesome-agentic-ai) - Learning hub that catalogs OpenClaw agents and indexes community OpenClaw skills, alongside Cursor and Claude Code material.
 
 ---
 


### PR DESCRIPTION
Adds https://github.com/adriannoes/awesome-agentic-ai under **Related Projects**.

This list is SOUL.md templates; I am not submitting a template. The hub cross-links the OpenClaw ecosystem (agent catalog + skills snapshot) with broader agentic coding learning material. Useful for readers who want context beyond a single deployable agent.

MIT. One link.