### PR TITLE
Add mnemosyne: zero-dependency cognitive memory engine (OpenClaw/Hermes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,11 @@ Skills for [Claude Code](https://claude.com/claude-code), invoked via slash comm
 - **[excalidraw-architecture](./skills/claude/excalidraw-architecture/)** — Generate/update an Excalidraw architecture diagram from the current codebase
 - **[cost-optimizer](./skills/claude/cost-optimizer/)** — Audit a project's Claude Code usage for cost wins (bloated memory, cache misses, over-pinned Opus)
 
+### [OpenClaw](./skills/) — OpenClaw / Hermes
+On-device skills for the [OpenClaw](https://openclaw.ai) and [Hermes](https://nousresearch.com/hermes) agents.
+
+- **[mnemosyne](https://github.com/ElonAug7/Mnemosyne-agentmemory-engine-openclaw-hermes)** — Zero-dependency cognitive memory engine: compound-cue theory retrieval (nDCG 0.238, 5.2× over BM25), pure Markdown storage, zero API keys, data never leaves the machine
+
 **[Browse all skills →](./skills/)**
 
 ---


### PR DESCRIPTION
## What

Adds **mnemosyne** under a new `OpenClaw / Hermes` subsection in the Skills section.

## Why it belongs here

- **On-device, zero-dependency** — pure Node.js + plain Markdown, no LLM API calls for retrieval, no vector DB, no embedding model
- **Cognitive-science retrieval** — compound-cue theory (Raaijmakers & Shiffrin 1981), time decay, testing effect, Zeigarnik effect
- **Measured quality** — Memory-Native Evaluation (80 queries, 11 systems): nDCG@10 0.238, 5.2× over previous version, beating raw BM25 (0.185) and all embedding systems — with zero embeddings
- **Data sovereignty** — every memory is a readable Markdown file, nothing leaves the machine
- **OpenClaw + Hermes native** — auto-injects memory protocol into SOUL.md/AGENTS.md on install

Repo: https://github.com/ElonAug7/Mnemosyne-agentmemory-engine-openclaw-hermes

Happy to adjust placement/wording per your conventions.