### PR TITLE
docs(readme): add Magic Hour skill to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Utilities and helpers for working with OpenClaw.
 | [agents.json](agents.json) | Machine-readable index of all 187 agent templates |
 | agent-validator | Validate SOUL.md syntax |
 | mcp-tester | Test MCP server connections |
+| [magic-hour skill](https://github.com/RhythmP28/clawhub-magic-hour) | OpenClaw/ClawHub skill for AI video and image generation (Sora 2, Veo 3.1, Kling 3.0, face swap, lip sync) via the Magic Hour API; free tier, hosted MCP at `https://mcp.magichour.ai/` |
 
 ---
 


### PR DESCRIPTION
## What does this PR add?
Adds the Magic Hour OpenClaw/ClawHub skill (https://github.com/RhythmP28/clawhub-magic-hour) to the Tools table. Magic Hour is an AI video/image generation API (Sora 2, Veo 3.1, Kling 3.0, Seedance, face swap, lip sync) — site https://magichour.ai, docs https://docs.magichour.ai, hosted MCP https://mcp.magichour.ai/. Free tier: 400 credits + 100/day, no card.

## Type
- [ ] New agent template
- [ ] Update existing template
- [x] Documentation improvement
- [ ] Bug fix
- [ ] Other

## Checklist
- [ ] SOUL.md follows the [template format](../CONTRIBUTING.md) (N/A, not an agent)
- [ ] README.md included with quick start guide (N/A)
- [ ] Agent placed in correct category folder (N/A)
- [x] Main README.md updated with new entry
- [ ] Tested the SOUL.md with OpenClaw locally (N/A)