### PR TITLE
Add SandBase CLI to Community MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ Model Context Protocol servers to extend agent capabilities.
 | mcp-twitter | Twitter/X posting |
 | mcp-discord | Discord bot integration |
 | mcp-linear | Linear issue tracking |
+| [SandBase CLI](https://github.com/sandbaseai/cli) | Local CLI/MCP bridge for OpenClaw and other agent clients, with one provider/model layer for 2,000+ AI models/APIs |
 
 ---
 


### PR DESCRIPTION
Closes #127.

Adds one factual entry to the existing Community MCP table. SandBase CLI is an Apache-2.0 local CLI/MCP bridge that works with OpenClaw and other agent clients, providing one provider/model layer for 2,000+ AI models/APIs.

Project: https://github.com/sandbaseai/cli