### PR TITLE
Add ClawMetry to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ Utilities and helpers for working with OpenClaw.
 | [agents.json](agents.json) | Machine-readable index of all 187 agent templates |
 | agent-validator | Validate SOUL.md syntax |
 | mcp-tester | Test MCP server connections |
+| [ClawMetry](https://github.com/vivekchand/clawmetry) | Self-hosted observability and kill switch for OpenClaw agents, reads the session logs already on disk so there is no SDK and nothing in the request path |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ Utilities and helpers for working with OpenClaw.
 | [agents.json](agents.json) | Machine-readable index of all 187 agent templates |
 | agent-validator | Validate SOUL.md syntax |
 | mcp-tester | Test MCP server connections |
-| [ClawMetry](https://github.com/vivekchand/clawmetry) | Self-hosted observability and kill switch for OpenClaw agents, reads the session logs already on disk so there is no SDK and nothing in the request path |
+| [ClawMetry](https://github.com/vivekchand/clawmetry) | Self-hosted observability and kill switch for OpenClaw agents, reads the session logs already on disk so there is no SDK and nothing in the request path ([clawmetry.com](https://clawmetry.com)) |
 
 ---
 


### PR DESCRIPTION
## What does this PR add?
Adds [ClawMetry](https://github.com/vivekchand/clawmetry) as one row in the **Tools** table. ClawMetry is a self-hosted, local-first observability dashboard plus a kill switch for OpenClaw agents (it also supports NemoClaw, Claude Code, Codex, Cursor, Gemini CLI and other runtimes). Install is `pip install clawmetry && clawmetry`, zero config, MIT licensed (open-core). It fits Tools because it is a utility for running OpenClaw day to day: sessions, transcripts, tool calls, tokens and cache-aware cost per session and per model, and a Guard tab that can pause, stop or kill a runaway agent (opt-in, off by default).

It gets its data by reading the session logs OpenClaw already writes on disk, so there is no SDK to install, nothing sits in the request path, and nothing leaves the machine by default (optional E2E-encrypted cloud sync exists). Pricing, stated plainly: OpenClaw and NemoClaw observability is free in the open-source app; the other runtimes need ClawMetry Cloud or a self-hosted Pro license. The row itself stays factual and short since the Tools table has no pricing column.

## Type
- [ ] New agent template
- [ ] Update existing template
- [x] Documentation improvement
- [ ] Bug fix
- [x] Other (new entry in the Tools table)

## Checklist
- [ ] SOUL.md follows the [template format](../CONTRIBUTING.md) (N/A, this is not an agent template)
- [ ] README.md included with quick start guide (N/A, this is not an agent template; the linked project has its own README with install instructions)
- [ ] Agent placed in correct category folder (N/A, not an agent)
- [x] Main README.md updated with new entry
- [ ] Tested the SOUL.md with OpenClaw locally (N/A, no SOUL.md; the tool itself runs against a local OpenClaw workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rt5fq2BWxieLpR69MAbwjr

Website: https://clawmetry.com
